### PR TITLE
ldap: AD: Add validation errors

### DIFF
--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -29,6 +29,15 @@ class LdapConfig extends PluginConfig {
                     this web server or does not have its DNS configured to
                     point to the AD servers',
                 'configuration' => array('size'=>40),
+                'validators' => array(
+                function($self, $val) {
+                    if (!$val) return;
+                    $servers = explode(',', $val);
+                    foreach ($servers as $s) {
+                        if (!Validator::is_ip(trim($s)))
+                            $self->addError($s.': Expected an IP address');
+                    }
+                }),
             )),
 
             'ldap' => new SectionBreakField(array(

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -15,6 +15,12 @@ class LdapConfig extends PluginConfig {
                 'label' => 'Default Domain',
                 'hint' => 'Default domain used in authentication and searches',
                 'configuration' => array('size'=>40),
+                'validators' => array(
+                function($self, $val) {
+                    if (strpos($val, '.') === false)
+                        $self->addError(
+                            'Fully-qualified domain name is expected');
+                }),
             )),
             'dns' => new TextboxField(array(
                 'label' => 'DNS Servers',


### PR DESCRIPTION
This ldap plugin doesn't support simple domain names, and the servers listed in the DNS box need to be comma-separated IP addresses
