### PR TITLE
Implement client authentication via LDAP

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -242,7 +242,7 @@ class LDAPAuthentication {
     function getSchema($connection) {
         $schema = $this->getConfig()->get('schema');
         if (!$schema || $schema == 'auto') {
-            $dse = $connection->rootDse();
+            $dse = $connection->rootDse(array('supportedCapabilities'));
             // Microsoft Active Directory
             // http://www.alvestrand.no/objectid/1.2.840.113556.1.4.800.html
             if (($caps = $dse->getValue('supportedCapabilities'))

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -366,7 +366,7 @@ class LDAPAuthentication {
                     break;
             }
             if (!$acct)
-                return;
+                return new ClientCreateRequest($this, $username, $info);
 
             if (($client = new ClientSession(new EndUser($acct->getUser())))
                     && !$client->getId())
@@ -421,10 +421,15 @@ class ClientLDAPAuthentication extends UserAuthenticationBackend {
 
     function __construct($config) {
         $this->_ldap = new LDAPAuthentication($config, 'client');
+        if ($domain = $config->get('domain'))
+            self::$name .= sprintf(' (%s)', $domain);
     }
 
     function authenticate($username, $password=false, $errors=array()) {
-        return $this->_ldap->authenticate($username, $password);
+        $object = $this->_ldap->authenticate($username, $password);
+        if ($object instanceof ClientCreateRequest)
+            $object->setBackend($this);
+        return $object;
     }
 }
 

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -226,8 +226,8 @@ class LDAPAuthentication {
 
         // Attempt to bind as the DN of the user looked up with the password
         // specified
-        $r = $c->bind($r->current()->dn(), $password);
-        if (PEAR::isError($r))
+        $bound = $c->bind($r->current()->dn(), $password);
+        if (PEAR::isError($bound))
             return null;
 
         // TODO: Save the DN in the config table so a lookup isn't necessary

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -444,9 +444,5 @@ class LdapAuthPlugin extends Plugin {
             StaffAuthenticationBackend::register(new StaffLDAPAuthentication($config));
         if ($config->get('auth-client'))
             UserAuthenticationBackend::register(new ClientLDAPAuthentication($config));
-
-        set_include_path(get_include_path().':'.dirname(__file__).'/include');
     }
 }
-
-?>

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -29,9 +29,9 @@ class LDAPAuthentication {
         'msad' => array(
             'user' => array(
                 'filter' => '(objectClass=user)',
-                'base' => 'CN=users',
-                'first' => 'firstName',
-                'last' => 'lastName',
+                'base' => 'CN=Users',
+                'first' => 'givenName',
+                'last' => 'sn',
                 'full' => 'displayName',
                 'email' => 'mail',
                 'phone' => 'telephoneNumber',
@@ -326,8 +326,8 @@ class LDAPAuthentication {
 
     function _getUserInfoArray($e, $schema) {
         // Detect first and last name if only full name is given
-        if (!($first = $e->getValue($schema['first']))
-                || !($last = $e->getValue($schema['last']))) {
+        if (!($first = $this->_getValue($e, $schema['first']))
+                || !($last = $this->_getValue($e, $schema['last']))) {
             $name = new PersonsName($this->_getValue($e, $schema['full']));
             $first = $name->getFirst();
             $last = $name->getLast();

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -169,6 +169,16 @@ class LdapConfig extends PluginConfig {
             $c = new Net_LDAP2($info);
             $r = $c->bind();
             if (PEAR::isError($r)) {
+                if (false === strpos($config['bind_dn'], '@')
+                        && false === strpos($config['bind_dn'], ',dc=')) {
+                    // Assume Active Directory, add the default domain in
+                    $config['bind_dn'] .= '@' . $config['domain'];
+                    $info['bind_dn'] = $config['bind_dn'];
+                    $c = new Net_LDAP2($info);
+                    $r = $c->bind();
+                }
+            }
+            if (PEAR::isError($r)) {
                 $connection_error =
                     $r->getMessage() .': Unable to bind to '.$info['host'];
             }

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -121,6 +121,8 @@ class LdapConfig extends PluginConfig {
         global $ost;
         if ($ost && !extension_loaded('ldap')) {
             $ost->setWarning('LDAP extension is not available');
+            $errors['err'] = 'LDAP extension is not available. Please
+                install or enable the `php-ldap` extension on your web server';
             return;
         }
 

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -91,6 +91,27 @@ class LdapConfig extends PluginConfig {
                     '2307' => 'Posix Account',
                 ),
             )),
+
+            'auth' => new SectionBreakField(array(
+                'label' => 'Authentication Modes',
+                'hint' => 'Accounts must be created locally for both clients and staff before they can be authenticated',
+                'hint' => 'Authentication modes for clients and staff
+                    members can be enabled independently',
+            )),
+            'auth-staff' => new BooleanField(array(
+                'label' => 'Staff Authentication',
+                'default' => true,
+                'configuration' => array(
+                    'desc' => 'Enable authentication of staff members'
+                )
+            )),
+            'auth-client' => new BooleanField(array(
+                'label' => 'Client Authentication',
+                'default' => false,
+                'configuration' => array(
+                    'desc' => 'Enable authentication of clients'
+                )
+            )),
         );
     }
 

--- a/auth-ldap/plugin.php
+++ b/auth-ldap/plugin.php
@@ -1,5 +1,5 @@
 <?php
-
+set_include_path(get_include_path().PATH_SEPARATOR.dirname(__file__).'/include');
 return array(
     'id' =>             'auth:ldap', # notrans
     'version' =>        '0.5',

--- a/auth-ldap/plugin.php
+++ b/auth-ldap/plugin.php
@@ -2,7 +2,7 @@
 
 return array(
     'id' =>             'auth:ldap', # notrans
-    'version' =>        '0.4',
+    'version' =>        '0.5',
     'name' =>           'LDAP Authentication and Lookup',
     'author' =>         'Jared Hancock',
     'description' =>    'Provides a configurable authentication backend


### PR DESCRIPTION
**This requires the `feature/client-login` for osTicket, or osTicket >= 1.9**

This patch enables client authentication for LDAP. Clients can use their AD credentials to access their tickets, and the system will match up the client account by the username or email address in the local osTicket system.
