### PR TITLE
oauth: Introduce external authentication with Google+

### DIFF
--- a/auth-oauth/authentication.php
+++ b/auth-oauth/authentication.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once(INCLUDE_DIR.'class.plugin.php');
+require_once('config.php');
+
+class OauthAuthPlugin extends Plugin {
+    var $config_class = "OauthPluginConfig";
+
+    function bootstrap() {
+        $config = $this->getConfig();
+
+        # ----- Google Plus ---------------------
+        $google = $config->get('g-enabled');
+        if (in_array($google, array('all', 'staff'))) {
+            require_once('google.php');
+            StaffAuthenticationBackend::register(
+                new GoogleStaffAuthBackend($this->getConfig()));
+        }
+        if (in_array($google, array('all', 'client'))) {
+            require_once('google.php');
+            UserAuthenticationBackend::register(
+                new GoogleClientAuthBackend($this->getConfig()));
+        }
+    }
+}
+
+require_once(INCLUDE_DIR.'UniversalClassLoader.php');
+use Symfony\Component\ClassLoader\UniversalClassLoader_osTicket;
+$loader = new UniversalClassLoader_osTicket();
+$loader->registerNamespaceFallbacks(array(
+    dirname(__file__).'/lib'));
+$loader->register();

--- a/auth-oauth/config.php
+++ b/auth-oauth/config.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once INCLUDE_DIR . 'class.plugin.php';
+
+class OauthPluginConfig extends PluginConfig {
+    function getOptions() {
+        $modes = new ChoiceField(array(
+            'label' => 'Authenticate',
+            'choices' => array(
+                '0' => 'Disabled',
+                'staff' => 'Agents Only',
+                'client' => 'Clients Only',
+                'all' => 'Agents and Clients',
+            ),
+        ));
+        return array(
+            'google' => new SectionBreakField(array(
+                'label' => 'Google+ Authentication',
+            )),
+            'g-client-id' => new TextboxField(array(
+                'label' => 'Client ID',
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
+            'g-client-secret' => new TextboxField(array(
+                'label' => 'Client Secret',
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
+            'g-enabled' => clone $modes,
+        );
+    }
+}

--- a/auth-oauth/google.php
+++ b/auth-oauth/google.php
@@ -1,0 +1,147 @@
+<?php
+
+use ohmy\Auth2;
+
+class GoogleAuth {
+    var $config;
+    var $access_token;
+
+    function __construct($config) {
+        $this->config = $config;
+    }
+
+    function triggerAuth() {
+        $self = $this;
+        return Auth2::legs(3)
+            ->set('id', $this->config->get('g-client-id'))
+            ->set('secret', $this->config->get('g-client-secret'))
+            ->set('redirect', 'http://' . $_SERVER['HTTP_HOST']
+                . ROOT_PATH . 'api/auth/ext')
+            ->set('scope', 'profile email')
+
+            ->authorize('https://accounts.google.com/o/oauth2/auth')
+            ->access('https://accounts.google.com/o/oauth2/token')
+
+            ->finally(function($data) use ($self) {
+                $self->access_token = $data['access_token'];
+            });
+    }
+}
+
+class GoogleStaffAuthBackend extends ExternalStaffAuthenticationBackend {
+    static $id = "google";
+    static $name = "Google Plus";
+
+    static $sign_in_image_url = "https://developers.google.com/+/images/branding/sign-in-buttons/White-signin_Long_base_44dp.png";
+    static $service_name = "Google+";
+
+    var $config;
+
+    function __construct($config) {
+        $this->config = $config;
+        $this->google = new GoogleAuth($config);
+    }
+
+    function signOn() {
+        // TODO: Check session for auth token
+        if (isset($_SESSION[':oauth']['email'])) {
+            if (($staff = new StaffSession($_SESSION[':oauth']['email']))
+                    && $staff->getId())
+                return $staff;
+
+            else
+                $_SESSION['_staff']['auth']['msg'] = 'Have your administrator create a local account';
+        }
+    }
+
+    static function signOut($user) {
+        parent::signOut($user);
+        unset($_SESSION[':oauth']);
+    }
+
+
+    function triggerAuth() {
+        parent::triggerAuth();
+        $google = $this->google->triggerAuth();
+        $google->GET(
+            "https://www.googleapis.com/oauth2/v1/tokeninfo?access_token="
+                . $this->google->access_token)
+            ->then(function($response) {
+                require_once INCLUDE_DIR . 'class.json.php';
+                if ($json = JsonDataParser::decode($response->text))
+                    $_SESSION[':oauth']['email'] = $json['email'];
+                Http::redirect(ROOT_PATH . 'scp');
+            }
+        );
+    }
+}
+
+class GoogleClientAuthBackend extends ExternalUserAuthenticationBackend {
+    static $id = "google.client";
+    static $name = "Google Plus";
+
+    static $sign_in_image_url = "https://developers.google.com/+/images/branding/sign-in-buttons/Red-signin_Long_base_44dp.png";
+    static $service_name = "Google+";
+
+    function __construct($config) {
+        $this->config = $config;
+        $this->google = new GoogleAuth($config);
+    }
+
+    function supportsInteractiveAuthentication() {
+        return false;
+    }
+
+    function signOn() {
+        // TODO: Check session for auth token
+        if (isset($_SESSION[':oauth']['email'])) {
+            if (($acct = ClientAccount::lookupByUsername($_SESSION[':oauth']['email']))
+                    && $acct->getId()
+                    && ($client = new ClientSession(new EndUser($acct->getUser()))))
+                return $client;
+
+            elseif (isset($_SESSION[':oauth']['profile'])) {
+                // TODO: Prepare ClientCreateRequest
+                $profile = $_SESSION[':oauth']['profile'];
+                $info = array(
+                    'email' => $_SESSION[':oauth']['email'],
+                    'name' => $profile['displayName'],
+                );
+                return new ClientCreateRequest($this, $info['email'], $info);
+            }
+        }
+    }
+
+    static function signOut($user) {
+        parent::signOut($user);
+        unset($_SESSION[':oauth']);
+    }
+
+    function triggerAuth() {
+        require_once INCLUDE_DIR . 'class.json.php';
+        parent::triggerAuth();
+        $google = $this->google->triggerAuth();
+        $token = $this->google->access_token;
+        $google->GET(
+            "https://www.googleapis.com/oauth2/v1/tokeninfo?access_token="
+                . $token)
+            ->then(function($response) use ($google, $token) {
+                if (!($json = JsonDataParser::decode($response->text)))
+                    return;
+                $_SESSION[':oauth']['email'] = $json['email'];
+                $google->GET(
+                    "https://www.googleapis.com/plus/v1/people/me?access_token="
+                        . $token)
+                    ->then(function($response) {
+                        if (!($json = JsonDataParser::decode($response->text)))
+                            return;
+                        $_SESSION[':oauth']['profile'] = $json;
+                        Http::redirect(ROOT_PATH . 'login.php');
+                    }
+                );
+            }
+        );
+    }
+}
+
+

--- a/auth-oauth/plugin.php
+++ b/auth-oauth/plugin.php
@@ -1,0 +1,23 @@
+<?php
+
+return array(
+    'id' =>             'auth:oath2', # notrans
+    'version' =>        '0.1',
+    'name' =>           'Oauth2 Authentication and Lookup',
+    'author' =>         'Jared Hancock',
+    'description' =>    'Provides a configurable authentication backend
+        for authenticating staff and clients using an OATH2 server
+        interface.',
+    'url' =>            'http://www.osticket.com/plugins/auth/oauth',
+    'plugin' =>         'authentication.php:OauthAuthPlugin',
+    'requires' => array(
+        "ohmy/auth" => array(
+            "version" => "*",
+            "map" => array(
+                "ohmy/auth/src" => 'lib',
+            )
+        ),
+    ),
+);
+
+?>


### PR DESCRIPTION
To register for Google+ authentication,
- Visit the Google Cloud Console (https://console.developers.google.com/)
- Sign in to Google via a relevant account
- Create a project (name it whatever -- osTicket Help Desk)
- Manage the project, navigate to APIs and Auth / Credentials and create an OAuth Client ID
- Register the key with the URL of your helpdesk plus `api/auth/ext` (`http://support.mycompany.com/api/auth/ext`). This is called the _Redirect URI_
- Navigate to APIs & Auth / Consent Screen and fill in the relevant information
- Navigate to APIs & Auth / APIs and add / enable the _Google+ API_
- Install the plugin in osTicket **1.9**
- Configure the plugin with your Google+ Client ID and Secret
- Configure the plugin to authenticate agents (staff), users or both
- Enable the OAuth plugin
- Log out and back in with Google+
- Enjoy!
