### PR TITLE
http: Implement pass-through auth for clients

### DIFF
--- a/auth-passthru/authenticate.php
+++ b/auth-passthru/authenticate.php
@@ -5,6 +5,10 @@ class HttpAuthentication extends StaffAuthenticationBackend {
     static $name = "HTTP Authentication";
     static $id = "passthru";
 
+    function supportsInteractiveAuthentication() {
+        return false;
+    }
+
     function signOn() {
         if (isset($_SERVER['REMOTE_USER']) && !empty($_SERVER['REMOTE_USER']))
             // User was authenticated by the HTTP server
@@ -30,8 +34,63 @@ class HttpAuthentication extends StaffAuthenticationBackend {
     }
 }
 
+class UserHttpAuthentication extends UserAuthenticationBackend {
+    static $name = "HTTP Authentication";
+    static $id = "passthru.client";
+
+    function supportsInteractiveAuthentication() {
+        return false;
+    }
+
+    function signOn() {
+        if (isset($_SERVER['REMOTE_USER']) && !empty($_SERVER['REMOTE_USER']))
+            // User was authenticated by the HTTP server
+            $username = $_SERVER['REMOTE_USER'];
+        elseif (isset($_SERVER['REDIRECT_REMOTE_USER'])
+                && !empty($_SERVER['REDIRECT_REMOTE_USER']))
+            $username = $_SERVER['REDIRECT_REMOTE_USER'];
+
+        if ($username) {
+            // Support ActiveDirectory domain specification with either
+            // "user@domain" or "domain\user" formats
+            if (strpos($username, '@') !== false)
+                list($username, $domain) = explode('@', $username, 2);
+            elseif (strpos($username, '\\') !== false)
+                list($domain, $username) = explode('\\', $username, 2);
+            $username = trim(strtolower($username));
+
+            if ($acct = ClientAccount::lookupByUsername($username)) {
+                if (($client = new ClientSession(new EndUser($acct->getUser())))
+                        && $client->getId())
+                    return $client;
+            }
+            else {
+                // No such account. Attempt a lookup on the username
+                $users = parent::searchUsers($username);
+                if (!is_array($users))
+                    return;
+
+                foreach ($users as $u) {
+                    if (0 === strcasecmp($u['username'], $username)
+                            || 0 === strcasecmp($u['email'], $username))
+                        // User information matches HTTP username
+                        return new ClientCreateRequest($this, $username, $u);
+                }
+            }
+        }
+    }
+}
+
+require_once(INCLUDE_DIR.'class.plugin.php');
+require_once('config.php');
 class PassthruAuthPlugin extends Plugin {
+    var $config_class = 'PassthruAuthConfig';
+
     function bootstrap() {
-        StaffAuthenticationBackend::register('HttpAuthentication');
+        $config = $this->getConfig();
+        if ($config->get('auth-staff'))
+            StaffAuthenticationBackend::register('HttpAuthentication');
+        if ($config->get('auth-client'))
+            UserAuthenticationBackend::register('UserHttpAuthentication');
     }
 }

--- a/auth-passthru/config.php
+++ b/auth-passthru/config.php
@@ -1,0 +1,38 @@
+<?php
+require_once(INCLUDE_DIR.'/class.forms.php');
+
+class PassthruAuthConfig extends PluginConfig {
+    function getOptions() {
+        return array(
+            'auth' => new SectionBreakField(array(
+                'label' => 'Authentication Modes',
+                'hint' => 'Authentication modes for clients and staff
+                    members can be enabled independently. Client discovery
+                    can be supported via a separate backend (such as LDAP)',
+            )),
+            'auth-staff' => new BooleanField(array(
+                'label' => 'Staff Authentication',
+                'default' => true,
+                'configuration' => array(
+                    'desc' => 'Enable authentication of staff members'
+                )
+            )),
+            'auth-client' => new BooleanField(array(
+                'label' => 'Client Authentication',
+                'default' => false,
+                'configuration' => array(
+                    'desc' => 'Enable authentication and discovery of clients'
+                )
+            )),
+        );
+    }
+
+    function pre_save(&$config, &$errors) {
+        global $msg;
+
+        if (!$errors)
+            $msg = 'Configuration updated successfully';
+
+        return true;
+    }
+}


### PR DESCRIPTION
Client authentication is read from the HTTP environment made available to osTicket. If the user does not yet exist in the system, a search will be performed against any (other) auth backends which support searching (such as LDAP). If a hit is found and the username or email address matches the HTTP username, the user is automatically created with the information returned in the search.
