### PR TITLE
reCaptcha: Add concept of Google reCaptcha field

### DIFF
--- a/field-recaptcha/config.php
+++ b/field-recaptcha/config.php
@@ -23,6 +23,12 @@ class reCaptchaConfig extends PluginConfig {
 
     function pre_save($config, &$errors) {
         // Todo: verify key
+
+        if (!function_exists('curl_init')) {
+            Messages::error('CURL extension is required');
+            return false;
+        }
+
         global $msg;
         if (!$errors)
             $msg = 'Successfully updated reCAPTCHA settings';

--- a/field-recaptcha/config.php
+++ b/field-recaptcha/config.php
@@ -1,0 +1,32 @@
+<?php
+
+class reCaptchaConfig extends PluginConfig {
+    function getOptions() {
+        return array(
+            '_' => new SectionBreakField(array(
+                'label' => 'reCaptcha Configuration',
+                'hint' => 'Requires separate registration for a key set'
+            )),
+            'public' => new TextboxField(array(
+                'required' => true,
+                'configuration'=>array('length'=>64, 'size'=>40),
+                'label' => 'Public Key',
+            )),
+            'private' => new TextboxField(array(
+                'widget' => 'PasswordWidget',
+                'required' => false,
+                'configuration'=>array('length'=>64, 'size'=>40),
+                'label' => 'Private Key',
+            )),
+        );
+    }
+
+    function pre_save($config, &$errors) {
+        // Todo: verify key
+        global $msg;
+        if (!$errors)
+            $msg = 'Successfully updated reCAPTCHA settings';
+
+        return true;
+    }
+}

--- a/field-recaptcha/field.php
+++ b/field-recaptcha/field.php
@@ -1,0 +1,90 @@
+<?php
+
+require_once INCLUDE_DIR . 'class.dynamic_forms.php';
+require_once INCLUDE_DIR . 'class.forms.php';
+
+class reCaptchaField extends FormField {
+    static $widget = 'reCaptchaWidget';
+    static $plugin_config;
+
+    function hasData() {
+        // Data in this field is not database-backed
+        return false;
+    }
+
+    function validateEntry($value) {
+        static $validation;
+
+        // ValidateEntry may be called twice, which is a problem
+        $id = $this->get('id');
+        $captcha = $this->getCaptcha();
+        if (!isset($validation[$id])) {
+            $I = &$validation[$id];
+            if (!($I['valid'] = $captcha->isValid())) {
+                if (!$captcha->getError())
+                    $captcha->setError();
+                $I['error'] = $captcha->getError();
+                if ($I['error'] == 'incorrect-captcha-sol')
+                    $I['error'] = "Your response doesn't look right. Please try again";
+            }
+        }
+        if (!$validation[$id]['valid'])
+            $this->_errors[] = $validation[$id]['error'];
+    }
+
+    function getCaptcha() {
+        $pconfig = static::$plugin_config;
+        $captcha = new ReCaptcha\Captcha(Internationalization::getCurrentLanguage());
+        $captcha->setPublicKey($pconfig->get('public'));
+        $captcha->setPrivateKey($pconfig->get('private'));
+        return $captcha;
+    }
+
+    function getConfigurationOptions() {
+        return array(
+            'theme' => new ChoiceField(array(
+                'label' => 'reCaptcha Theme',
+                'choices' => array('red' => 'Red', 'white' => 'White',
+                    'blackglass'=>'Black Glass', 'clean' => 'Clean'),
+                'default' => 'red',
+            )),
+        );
+    }
+}
+
+class reCaptchaWidget extends Widget {
+    function render() {
+        $captcha = $this->field->getCaptcha();
+        $fconfig = $this->field->getConfiguration();
+        echo $captcha->displayHTML($fconfig['theme']);
+    }
+
+    function getValue() {
+        // noop — handled by the ReCaptcha library
+        return 'junk';
+    }
+}
+
+require_once 'config.php';
+
+use Symfony\Component\ClassLoader\UniversalClassLoader_osTicket;
+
+class reCaptchaPlugin extends Plugin {
+    var $config_class = 'reCaptchaConfig';
+
+    function bootstrap() {
+        reCaptchaField::$plugin_config = $this->getConfig();
+        FormField::addFieldTypes(__('Verification'), function() {
+            return array(
+                'recaptcha' => array('Google reCAPTCHA', 'reCaptchaField')
+            );
+        });
+
+        require_once(INCLUDE_DIR.'UniversalClassLoader.php');
+        $loader = new UniversalClassLoader_osTicket();
+        $loader->registerNamespaces(array(
+            'ReCaptcha' => dirname(__file__) . '/lib',
+        ));
+        $loader->register();
+    }
+}

--- a/field-recaptcha/field.php
+++ b/field-recaptcha/field.php
@@ -7,67 +7,132 @@ class reCaptchaField extends FormField {
     static $widget = 'reCaptchaWidget';
     static $plugin_config;
 
-    function hasData() {
-        // Data in this field is not database-backed
-        return false;
+    function getPluginConfig() {
+        return static::$plugin_config;
     }
 
     function validateEntry($value) {
-        static $validation;
+        static $validation = array();
 
+        parent::validateEntry($value);
         // ValidateEntry may be called twice, which is a problem
         $id = $this->get('id');
-        $captcha = $this->getCaptcha();
+        $config = $this->getPluginConfig()->getInfo();
         if (!isset($validation[$id])) {
+            list($code, $json) = $this->http_post(
+                'https://www.google.com/recaptcha/api/siteverify',
+                array(
+                    'secret' => $config['private'],
+                    'response' => $value,
+                    'remoteip' => $_SERVER['REMOTE_ADDR'],
+            ));
+            if ($code !== 200) {
+                $response = array(
+                    'error-codes' => array('no-response'),
+                );
+            }
+            else {
+                $response = JsonDataParser::decode($json);
+            }
             $I = &$validation[$id];
-            if (!($I['valid'] = $captcha->isValid())) {
-                if (!$captcha->getError())
-                    $captcha->setError();
-                $I['error'] = $captcha->getError();
-                if ($I['error'] == 'incorrect-captcha-sol')
-                    $I['error'] = "Your response doesn't look right. Please try again";
+            if (!($I['valid'] = $response['success'])) {
+                $errors = array();
+                foreach ($response['error-codes'] as $code) {
+                    switch ($code) {
+                    case 'missing-input-response':
+                        $errors[] = sprintf(__('%s is a required field'),
+                            $this->getLabel() ?: __('This'));
+                        break;
+                    case 'invalid-input-response':
+                        $errors[] = "Your response doesn't look right. Please try again";
+                        break;
+                    case 'no-response':
+                        $errors[] = "Unable to communicate with the reCaptcha server";
+                    }
+                }
+                $I['errors'] = $errors;
             }
         }
         if (!$validation[$id]['valid'])
-            $this->_errors[] = $validation[$id]['error'];
+            foreach ($validation[$id]['errors'] as $e)
+                $this->_errors[] = $e;
     }
 
-    function getCaptcha() {
-        $pconfig = static::$plugin_config;
-        $captcha = new ReCaptcha\Captcha(Internationalization::getCurrentLanguage());
-        $captcha->setPublicKey($pconfig->get('public'));
-        $captcha->setPrivateKey($pconfig->get('private'));
-        return $captcha;
+    protected function http_post($url, array $data) {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'osTicket/'.THIS_VERSION);
+        curl_setopt($ch, CURLOPT_HEADER, FALSE);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, FALSE);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        if (isset($_SERVER['HTTPS_PROXY']))
+            curl_setopt($ch, CURLOPT_PROXY, $_SERVER['HTTPS_PROXY']);
+            
+        $result=curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return array($code, $result);
     }
 
     function getConfigurationOptions() {
         return array(
             'theme' => new ChoiceField(array(
                 'label' => 'reCaptcha Theme',
-                'choices' => array('red' => 'Red', 'white' => 'White',
-                    'blackglass'=>'Black Glass', 'clean' => 'Clean'),
-                'default' => 'red',
+                'choices' => array('dark' => 'Dark', 'light' => 'Light'),
+                'default' => 'light',
             )),
+            'type' => new ChoiceField(array(
+                'label' => 'reCaptcha Type',
+                'choices' => array('image' => 'Image', 'audio' => 'Audio'),
+                'default' => 'image',
+            )),
+            'size' => new ChoiceField(array(
+                'label' => 'reCaptcha Type',
+                'choices' => array('compact' => 'Compact', 'normal' => 'Normal'),
+                'default' => 'normal',
+            )),
+        );
+    }
+
+    function getMedia() {
+        return array(
+            'js' => array(
+                '//www.google.com/recaptcha/api.js?hl='
+                    . Internationalization::getCurrentLanguage()
+            ),
         );
     }
 }
 
 class reCaptchaWidget extends Widget {
     function render() {
-        $captcha = $this->field->getCaptcha();
         $fconfig = $this->field->getConfiguration();
-        echo $captcha->displayHTML($fconfig['theme']);
+        $pconfig = $this->field->getPluginConfig()->getInfo();
+        ?>
+        <div class="g-recaptcha"
+            data-sitekey="<?php echo $pconfig['public']; ?>"
+            data-theme="<?php echo $fconfig['theme'] ?: 'light'; ?>"
+            data-type="<?php echo $fconfig['type'] ?: 'image'; ?>"
+            data-size="<?php echo $fconfig['size'] ?: 'normal'; ?>"
+        ></div>
+<?php
     }
 
     function getValue() {
-        // noop — handled by the ReCaptcha library
-        return 'junk';
+        if (!($data = $this->field->getSource()))
+            return null;
+
+        if (!isset($data['g-recaptcha-response']))
+            return null;
+
+        return $data['g-recaptcha-response'];
     }
 }
 
 require_once 'config.php';
-
-use Symfony\Component\ClassLoader\UniversalClassLoader_osTicket;
 
 class reCaptchaPlugin extends Plugin {
     var $config_class = 'reCaptchaConfig';
@@ -79,12 +144,5 @@ class reCaptchaPlugin extends Plugin {
                 'recaptcha' => array('Google reCAPTCHA', 'reCaptchaField')
             );
         });
-
-        require_once(INCLUDE_DIR.'UniversalClassLoader.php');
-        $loader = new UniversalClassLoader_osTicket();
-        $loader->registerNamespaces(array(
-            'ReCaptcha' => dirname(__file__) . '/lib',
-        ));
-        $loader->register();
     }
 }

--- a/field-recaptcha/plugin.php
+++ b/field-recaptcha/plugin.php
@@ -10,12 +10,4 @@ return array(
     tickets by guests as well as client registration',
     'url' =>            'http://www.osticket.com/plugins/field/recaptcha',
     'plugin' =>         'field.php:reCaptchaPlugin',
-    'requires' => array(
-        "recaptcha-lib/recaptcha" => array(
-            'version' => "*",
-            'map' => array(
-                "recaptcha-lib/recaptcha/lib" => "lib",
-            ),
-        ),
-    ),
 );

--- a/field-recaptcha/plugin.php
+++ b/field-recaptcha/plugin.php
@@ -1,0 +1,21 @@
+<?php
+
+return array(
+    'id' =>             'field:reCAPTCHA', # notrans
+    'version' =>        '0.1',
+    'name' =>           'Google reCAPTCHA field',
+    'author' =>         'Jared Hancock',
+    'description' =>    'Provides a reCAPTCHA field which can be added to
+    the contact information. This will help verify humans for both new
+    tickets by guests as well as client registration',
+    'url' =>            'http://www.osticket.com/plugins/field/recaptcha',
+    'plugin' =>         'field.php:reCaptchaPlugin',
+    'requires' => array(
+        "recaptcha-lib/recaptcha" => array(
+            'version' => "*",
+            'map' => array(
+                "recaptcha-lib/recaptcha/lib" => "lib",
+            ),
+        ),
+    ),
+);


### PR DESCRIPTION
### Outstanding
- [ ] The "red" theme at least does not render properly due to a stylesheet error in the client theme
  CSS
### Screenshots
##### When installed and enabled, adds a new field type to the "Verification" fields category

![screen shot 2014-12-30 at 12 03 56 pm](https://cloud.githubusercontent.com/assets/672074/5581242/038afed6-901c-11e4-8e91-7f9fd2b04706.png)
##### Plugin has a configurable reCaptcha theme

![screen shot 2014-12-30 at 12 04 11 pm](https://cloud.githubusercontent.com/assets/672074/5581245/16c1f95a-901c-11e4-96a6-dc93a4ef4922.png)
##### Add it to the "Contact Information" form for new ticket and registration CAPTCHA support

![screen shot 2014-12-30 at 12 06 28 pm](https://cloud.githubusercontent.com/assets/672074/5581254/5a9681dc-901c-11e4-8ae5-3b8d563732e4.png)
##### The included recaptcha-lib includes translations out-of-the box

![screen shot 2014-12-30 at 12 06 44 pm](https://cloud.githubusercontent.com/assets/672074/5581257/5e626948-901c-11e4-8da8-8b825fb11f6b.png)
