### PR TITLE
Allow for longer folder names in the storage-fs plugin

### DIFF
--- a/storage-fs/storage.php
+++ b/storage-fs/storage.php
@@ -84,7 +84,7 @@ class FsStoragePluginConfig extends PluginConfig {
                     web server. If the path starts with neither a `/` or a
                     drive letter, the path will be assumed to be relative to
                     the root of osTicket',
-                'configuration'=>array('size'=>40),
+                'configuration'=>array('size'=>60, 'length'=>255),
                 'required'=>true,
             )),
         );


### PR DESCRIPTION
Maybe fixes #34
