### PR TITLE
ldap, passthru: Fix login with osTicket v1.9-next (post v1.9.7)

### DIFF
--- a/auth-ldap/plugin.php
+++ b/auth-ldap/plugin.php
@@ -2,7 +2,7 @@
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(__file__).'/include');
 return array(
     'id' =>             'auth:ldap', # notrans
-    'version' =>        '0.6.1',
+    'version' =>        '0.6.2',
     'name' =>           /* trans */ 'LDAP Authentication and Lookup',
     'author' =>         'Jared Hancock',
     'description' =>    /* trans */ 'Provides a configurable authentication backend

--- a/auth-passthru/authenticate.php
+++ b/auth-passthru/authenticate.php
@@ -26,8 +26,13 @@ class HttpAuthentication extends StaffAuthenticationBackend {
                 list($domain, $username) = explode('\\', $username, 2);
             $username = trim(strtolower($username));
 
-            if (($user = new StaffSession($username)) && $user->getId())
+            if (($user = StaffSession::lookup($username)) && $user->getId()) {
+                if (!$user instanceof StaffSession) {
+                    // osTicket <= v1.9.7 or so
+                    $user = new StaffSession($user->getId());
+                }
                 return $user;
+            }
 
             // TODO: Consider client sessions
         }

--- a/auth-passthru/plugin.php
+++ b/auth-passthru/plugin.php
@@ -2,7 +2,7 @@
 
 return array(
     'id' =>             'auth:passthru', # notrans
-    'version' =>        '0.1',
+    'version' =>        '0.2',
     'name' =>           /* trans */ 'HTTP Passthru Authentication',
     'author' =>         'Jared Hancock',
     'description' =>    /* trans */ 'Allows for the HTTP server (Apache or IIS) to perform


### PR DESCRIPTION
This fixes a login crash when using the LDAP and passthru plugins with the osTicket-1.8 `develop-next` branch
