### PR TITLE
ldap: Fix autodiscovery for Active Directory

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -149,7 +149,14 @@ class LDAPAuthentication {
         });
         // Locate closest domain controller (if requested)
         if ($closestOnly) {
-            if ($idx = self::findClosestLdapServer($servers, $config)) {
+            // If there are no servers from DNS, but there is one saved in the
+            // config, return that one
+            if (count($servers) === 0
+                && $config && ($T = $config->get('closest'))
+            ) {
+                return array($T);
+            }
+            if (is_int($idx = self::findClosestLdapServer($servers, $config))) {
                 return array($servers[$idx]);
             }
         }

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -316,8 +316,7 @@ class LDAPAuthentication {
             }
             $params = $defaults + $s;
             $c = new Net_LDAP2($params);
-            $r = $c->bind();
-            if (!PEAR::isError($r)) {
+            if ($this->_bind($c)) {
                 $connection = $c;
                 return $c;
             }

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -223,11 +223,11 @@ class LDAPAuthentication {
                     if (!in_array($error, array(SOCKET_EINPROGRESS, SOCKET_EALREADY))) {
                         // Bad mojo
                         socket_close($sk);
-                        unset($sockets,$i);
+                        unset($sockets[$i]);
                     }
                 }
             }
-            // Look for anothe rserver
+            // Look for another server
             list($i, $S) = each($servers);
             if ($S) {
                 // Add another socket to the list

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -37,6 +37,7 @@ class LDAPAuthentication {
                 'phone' => 'telephoneNumber',
                 'mobile' => false,
                 'username' => 'sAMAccountName',
+                'avatar' => array('jpegPhoto', 'thumbnailPhoto'),
                 'dn' => '{username}@{domain}',
                 'search' => '(&(objectCategory=person)(objectClass=user)(|(sAMAccountName={q}*)(firstName={q}*)(lastName={q}*)(displayName={q}*)))',
                 'lookup' => '(&(objectCategory=person)(objectClass=user)({attr}={q}))',
@@ -58,6 +59,7 @@ class LDAPAuthentication {
                 'phone' => 'telephoneNumber',
                 'mobile' => 'mobileTelephoneNumber',
                 'username' => 'uid',
+                'avatar' => 'jpegPhoto',
                 'dn' => 'uid={username},{search_base}',
                 'search' => '(&(objectClass=inetOrgPerson)(|(uid={q}*)(displayName={q}*)(cn={q}*)))',
                 'lookup' => '(&(objectClass=inetOrgPerson)({attr}={q}))',
@@ -642,6 +644,91 @@ class ClientLDAPAuthentication extends UserAuthenticationBackend {
     }
 }
 
+if (defined('MAJOR_VERSION') && version_compare(MAJOR_VERSION, '1.10', '>=')) {
+    require_once INCLUDE_DIR . 'class.avatar.php';
+
+    class LdapAvatarSource
+    extends AvatarSource {
+        static $id = 'ldap';
+        static $name = 'LDAP and Active Directory';
+
+        static $config;
+
+        function getAvatar($user) {
+            return new LdapAvatar($user);
+        }
+
+        static function registerUrl($config) {
+            static::$config = $config;
+            Signal::connect('api', function($dispatcher) {
+                $dispatcher->append(
+                    url_get('^/ldap/avatar$', array('LdapAvatarSource', 'tryFetchAvatar'))
+                );
+            });
+        }
+
+        static function tryFetchAvatar() {
+            static::fetchAvatar();
+            // if fetchAvatar is successful, then it won't return
+            Http::redirect(ROOT_PATH.'images/mystery-oscar.png');
+        }
+
+        static function fetchAvatar() {
+            $ldap = new LDAPAuthentication(static::$config);
+
+            if (!($c = $ldap->getConnection()))
+                return null;
+
+            // This requires a search user to be defined
+            if (!$ldap->_bind($c))
+                return null;
+
+            $schema_type = $ldap->getSchema($c);
+            $schema = $ldap::$schemas[$schema_type]['user'];
+            list($email, $username) =
+                Net_LDAP2_Util::escape_filter_value(array(
+                    $_GET['email'], $_GET['username']));
+
+            $r = $c->search(
+                $ldap->getSearchBase(),
+                sprintf('(|(%s=%s)(%s=%s))', $schema['email'], $email,
+                    $schema['username'], $username),
+                array(
+                    'sizelimit' => 1,
+                    'attributes' => array_filter(flatten(array(
+                        $schema['avatar']
+                    ))),
+                )
+            );
+            if (PEAR::isError($r) || !$r->count())
+                return null;
+
+            if (!($avatar = $ldap->_getValue($r->current(), $schema['avatar'])))
+                return null;
+
+            // Ensure the value is cacheable
+            $etag = md5($avatar);
+            Http::cacheable($etag, false, 86400);
+            Http::response(200, $avatar, 'image/jpeg', false);
+        }
+    }
+
+    class LdapAvatar
+    extends Avatar {
+        function getUrl($size) {
+            $user = $this->user;
+            $acct = $user instanceof User
+                ? $this->user->getAccount()
+                : $user;
+            return ROOT_PATH . 'api/ldap/avatar?'
+                .Http::build_query(array(
+                    'email' => $this->user->getEmail(),
+                    'username' => $acct ? $acct->username : '',
+                ));
+        }
+    }
+}
+
 require_once(INCLUDE_DIR.'class.plugin.php');
 require_once('config.php');
 class LdapAuthPlugin extends Plugin {
@@ -653,5 +740,9 @@ class LdapAuthPlugin extends Plugin {
             StaffAuthenticationBackend::register(new StaffLDAPAuthentication($config));
         if ($config->get('auth-client'))
             UserAuthenticationBackend::register(new ClientLDAPAuthentication($config));
+        if (class_exists('LdapAvatarSource')) {
+            AvatarSource::register('LdapAvatarSource');
+            LdapAvatarSource::registerUrl($config);
+        }
     }
 }

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -62,7 +62,10 @@ class LdapConfig extends PluginConfig {
             'servers' => new TextareaField(array(
                 'id' => 'servers',
                 'label' => $__('LDAP servers'),
-                'configuration' => array('html'=>false, 'rows'=>2, 'cols'=>40),
+                'configuration' => array('html'=>false, 'rows'=>2,
+                    'cols'=>40,
+                    'placeholder' => $__('Auto detect (recommended for Active Directory)'),
+                ),
                 'hint' => $__('Use "server" or "server:port". Place one server entry per line'),
             )),
             'tls' => new BooleanField(array(
@@ -141,13 +144,37 @@ class LdapConfig extends PluginConfig {
             return;
         }
 
+        // Discover LDAP servers for this domain
         if ($config['domain'] && !$config['servers']) {
             if (!($servers = LDAPAuthentication::autodiscover($config['domain'],
-                    preg_split('/,?\s+/', $config['dns']))))
+                array_filter(preg_split('/,?\s+/', $config['dns']))))
+            ) {
                 $this->getForm()->getField('servers')->addError(
                     $__("Unable to find LDAP servers for this domain. Try giving
                     an address of one of the DNS servers or manually specify
                     the LDAP servers for this domain below."));
+            }
+            // Attemt to discover the closest server
+            elseif (false !== ($idx =
+                LDAPAuthentication::findClosestLdapServer($servers))
+            ) {
+                if (class_exists('Messages')) { # added in v1.10
+                    Messages::info(sprintf(
+                        $__('%s was detected as the closest LDAP server. If this is not true, set the servers manually'),
+                        $servers[$idx]['host']));
+                }
+                $servers = array($servers[$idx]);
+            }
+            elseif ($idx === null) {
+                $this->getForm()->getField('servers')->addError(
+                sprintf($__(
+                    "No autodiscovered servers (%s) seem to be responding"
+                    ), implode(', ', array_map(
+                        function($a) { return $a['host']; },
+                        $servers))
+                ));
+            }
+            // else scanning might not be supported by PHP
         }
         else {
             if (!$config['servers'])
@@ -160,6 +187,7 @@ class LdapConfig extends PluginConfig {
                     $servers[] = array('host' => $host);
             }
         }
+
         $connection_error = false;
         foreach ($servers as $info) {
             // Assume MSAD
@@ -181,6 +209,12 @@ class LdapConfig extends PluginConfig {
                 'LDAP_OPT_TIMELIMIT' => 5,
                 'LDAP_OPT_NETWORK_TIMEOUT' => 5,
             );
+            // Break 'port' to a separate option
+            @list($host, $port) = explode(':', $info['host'], 2);
+            if ($port) {
+                $info['port'] = $port;
+                $info['host'] = $host;
+            }
             $c = new Net_LDAP2($info);
             $r = $c->bind();
             if (PEAR::isError($r)) {


### PR DESCRIPTION
There are a couple problems with the current autodiscover protocol in the plugin:
- Net_DNS2 does not support auto-discovery of DNS servers on Windows platforms, and so cannot lookup the LDAP servers
- The configuration pre_save does not properly handle empty DNS server listing, and so offers incorrect negative feedback when leaving the LDAP servers box and DNS servers boxes blank
- Multi-site Active Directory deployments may have servers that are far away from the osTicket server. Windows rates all servers with the same weight and priority. Therefore, osTicket will likely select a poor server from the list to bind to and search

This patch adds support for automatically discovering the closest domain controller (LDAP server) by asynchronously connecting to all domain controllers advertised in DNS, sorted by priority and weight, in parallel and using the first server to respond.

The protocol is described by Microsoft at
https://technet.microsoft.com/en-us/library/cc978016.aspx
