### PR TITLE
Update make.php

### DIFF
--- a/make.php
+++ b/make.php
@@ -685,7 +685,7 @@ EOF;
 
         $this->ensureComposer();
 
-        $php = defined('PHP_BINARY') ? PHP_BINARY : 'php';
+        $php = defined("'PHP_BINARY'") ? PHP_BINARY : 'php';
         if (file_exists(dirname(__file__)."/composer.lock")) {
             if ($autoupdate)
                 passthru($php." ".dirname(__file__)."/composer.phar -v update");


### PR DESCRIPTION
Need to quote PHP_BINARY's that have spaces e.g. on Windows PHP installations performed by Web Platform Installer.
