### PR TITLE
Update make.php

### DIFF
--- a/make.php
+++ b/make.php
@@ -666,7 +666,7 @@ class PluginBuilder extends Module {
     "repositories": [
         {
             "type": "pear",
-            "url": "http://pear.php.net"
+            "url": "https://pear.php.net"
         }
     ],
     "require": %s,


### PR DESCRIPTION
Change the composer pear repo to https from http.  This is necessary for newer versions of composer that do not allow unrestricted connections unless secure-http is set to false, which is NOT recommended.  Without this change, running hydrate or composer update will result in an error and fail.

https://getcomposer.org/doc/06-config.md#secure-http
