### PR TITLE
Use _bind() in getConnection()

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -152,8 +152,7 @@ class LDAPAuthentication {
         foreach ($this->getServers() as $s) {
             $params = $defaults + $s;
             $c = new Net_LDAP2($params);
-            $r = $c->bind();
-            if (!PEAR::isError($r)) {
+            if ($this->_bind($c)) {
                 $connection = $c;
                 return $c;
             }


### PR DESCRIPTION
If the LDAP server does not support anonymous bindings authentication will fail. Use the provided credentials to fix the getConnection() logic.
