### PR TITLE
thread: Add action to remove responses and notes

### DIFF
--- a/thread-action-delete/plugin.php
+++ b/thread-action-delete/plugin.php
@@ -1,0 +1,13 @@
+<?php
+
+return array(
+    'id' =>             'thread-entry:delete', # notrans
+    'version' =>        '0.1',
+    'name' =>           /* trans */ 'Delete plugin for thread entries',
+    'author' =>         'Jared Hancock',
+    'description' =>    /* trans */ 'Allows administrators to remove thread entry items',
+    'url' =>            'http://www.osticket.com/plugins/thread-entry/remove',
+    'plugin' =>         'tea_remove.php:TEA_RemovePlugin'
+);
+
+?>

--- a/thread-action-delete/tea_remove.php
+++ b/thread-action-delete/tea_remove.php
@@ -1,0 +1,116 @@
+<?php
+class TEA_RemoveThreadEntry extends ThreadEntryAction {
+    static $id = 'delete';
+    static $name = /* trans */ 'Delete';
+    static $icon = 'remove';
+
+    static $plugin_config;
+
+    static function setConfig(PluginConfig $config) {
+        static::$plugin_config = $config->getInfo();
+    }
+
+    function getConfig() {
+        return static::$plugin_config;
+    }
+
+    function isVisible() {
+        $config = $this->getConfig();
+
+        // Removal of messages is not allowed
+        if ($this->entry->type == 'M')
+            return false;
+
+        // Configuration indicates if removal of responses is allowed
+        if ($this->entry->type == 'R' && !@$config['responses'])
+            return false;
+
+        // Can't remove system posts
+        return ($this->entry->staff_id || $this->entry->user_id)
+            && $this->isEnabled();
+    }
+
+    function isEnabled() {
+        global $thisstaff;
+
+        // You have to be an admin *and* have access to the ticket/task
+        $T = $this->entry->getThread()->getObject();
+        return $thisstaff->isAdmin()
+            && $T->checkStaffPerm($thisstaff);
+    }
+
+    function getJsStub() {
+        return sprintf(<<<JS
+var url = '%s';
+$.dialog(url, [201], function(xhr, resp) {
+  var json = JSON.parse(resp);
+  if (!json || !json.thread_id)
+    return;
+  $('#thread-entry-'+json.thread_id)
+    .remove();
+});
+JS
+        , $this->getAjaxUrl());
+    }
+
+    function trigger() {
+        switch ($_SERVER['REQUEST_METHOD']) {
+        case 'GET':
+            return $this->trigger__get();
+        case 'POST':
+            return $this->trigger__post();
+        }
+    }
+
+    protected function trigger__get() {
+        global $cfg, $thisstaff;
+
+        $poster = $this->entry->getStaff();
+        $action = str_replace('ajax.php/','#', $this->getAjaxUrl());
+
+        include 'templates/thread-entry-delete.tmpl.php';
+    }
+
+    protected function trigger__post() {
+        $config = $this->getConfig();
+
+        if ($this->entry->type == 'M') {
+            Messages::error(__('Deletion of messages is not supported'));
+        }
+        if ($this->entry->type == 'R' && !@$config['responses']) {
+            Messages::error(__('Deletion of responses is disabled'));
+        }
+        elseif ($this->entry->delete()) {
+            Http::response('201', JsonDataEncoder::encode(array(
+                'thread_id' => $this->entry->id,
+            )));
+        }
+        return $this->trigger__get();
+    }
+}
+
+class TEA_RemovePlugin
+extends Plugin {
+    var $config_class = 'TEA_RemovePluginConfig';
+
+    function bootstrap() {
+        TEA_RemoveThreadEntry::setConfig($this->getConfig());
+        ThreadEntry::registerAction(/* trans */ 'Manage', 'TEA_RemoveThreadEntry');
+    }
+}
+
+class TEA_RemovePluginConfig
+extends PluginConfig {
+    function getOptions() {
+        return array(
+            'responses' => new BooleanField(array(
+                'label' => 'Allow removal of Responses',
+                'default' => false,
+                'hint' => 'Not recommended. Removing responses which were emailed to your users could cause significant confusion',
+                'configuration' => array(
+                    'desc' => 'Allow removal of Responses',
+                ),
+            )),
+        );
+    }
+}

--- a/thread-action-delete/templates/thread-entry-delete.tmpl.php
+++ b/thread-action-delete/templates/thread-entry-delete.tmpl.php
@@ -1,0 +1,37 @@
+<h3 class="drag-handle"><?php echo __("Remove Thread Entry"); ?></h3>
+<b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
+<div class="clear"></div>
+<hr />
+
+<?php 
+foreach (Messages::getMessages() as $M) { ?>
+    <div class="<?php echo strtolower($M->getLevel()); ?>-banner"><?php
+        echo (string) $M; ?></div>
+<?php } ?>
+
+<div style="margin: 1em">
+    <p>
+    <?php echo __(
+        "Are you sure you want to remove this?"); ?>
+    </p><p>
+    <?php echo __(
+        "Deleted data CANNOT be recovered."); ?>
+    </p>
+</div>
+
+<form method="post" name="delete" id="delete"
+    action="<?php echo $action; ?>">
+    <hr />
+    <p class="full-width">
+        <span class="buttons pull-left">
+            <input type="button" name="cancel" class="close"
+            value="<?php echo __('Cancel'); ?>">
+        </span>
+        <span class="buttons pull-right">
+            <input type="submit" class="red button" value="<?php
+            echo $verb ?: __('Delete'); ?>">
+        </span>
+     </p>
+</form>
+</div>
+<div class="clear"></div>


### PR DESCRIPTION
This will allow an administrator with access to a thread to remove notes and optionally responses. This might be useful if the items were accidently double posted or the information was posted to an incorrect thread.

![image](https://cloud.githubusercontent.com/assets/672074/21615973/611cd02a-d1a5-11e6-96fd-63e1f4d11cd6.png)

#### Responses can be optionally allowed for removal
![image](https://cloud.githubusercontent.com/assets/672074/21616005/84ccb8f0-d1a5-11e6-8902-e3d309255ea3.png)

### Outstanding
  * [ ] Add translation support
