### PR TITLE
auth-oauth: Google: Allow domain whitelisting

### DIFF
--- a/auth-oauth/config.php
+++ b/auth-oauth/config.php
@@ -39,6 +39,14 @@ class OauthPluginConfig extends PluginConfig {
                 'label' => $__('Client Secret'),
                 'configuration' => array('size'=>60, 'length'=>100),
             )),
+            'g-allowed-domains-agents' => new TextboxField(array(
+                'label' => $__('Allowed Domains for Agents'),
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
+            'g-allowed-domains-clients' => new TextboxField(array(
+                'label' => $__('Allowed Domains for Clients'),
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
             'g-enabled' => clone $modes,
         );
     }


### PR DESCRIPTION
Add options to define whitelisted domains for agents and clients
when signing in with Google. The options accept comma-separated
list of domains.