### PR TITLE
ldap: PHP 7.2+ Host:Port Conflict

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -117,7 +117,10 @@ class LDAPAuthentication {
         if ($servers) {
             $hosts = array();
             foreach ($servers as $h)
-                $hosts[] = array('host'=>$h);
+                if (preg_match('/([^:]+):(\d{1,4})/', $h, $matches))
+                    $hosts[] = array('host' => $matches[1], 'port' => $matches[2]);
+                else
+                    $hosts[] = array('host' => $h);
             return $hosts;
         }
     }

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -157,7 +157,10 @@ class LdapConfig extends PluginConfig {
             else {
                 $servers = array();
                 foreach (preg_split('/\s+/', $config['servers']) as $host)
-                    $servers[] = array('host' => $host);
+                    if (preg_match('/([^:]+):(\d{1,4})/', $host, $matches))
+                        $servers[] = array('host' => $matches[1], 'port' => $matches[2]);
+                    else
+                        $servers[] = array('host' => $host);
             }
         }
         $connection_error = false;


### PR DESCRIPTION
This addresses #160 where setting `host:port` for the "LDAP Servers" option does not work when using PHP 7.2+. In PHP 7.2+ the `host:port` string will be used as the full hostname and since we are not passing a port the system assumes `389`. The end result of this is `host:port:389` which is not valid and fails every time. This adds a regex check for the port number in the string and if exists we add the port number to the `port` option in the `$info` array for `Net_LDAP2::bind()`.  The end result of this is `host:port` which is valid and will connect successfully every time. If no port is passed the system assumes the port is the default (`389`) and the end result will be `host:389`.