### PR TITLE
issue: Password Validation

### DIFF
--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -87,6 +87,7 @@ class LdapConfig extends PluginConfig {
             'bind_pw' => new TextboxField(array(
                 'widget' => 'PasswordWidget',
                 'label' => $__('Password'),
+                'validator' => 'noop',
                 'hint' => $__("Password associated with the DN's account"),
                 'configuration' => array('size'=>40),
             )),


### PR DESCRIPTION
This addresses an issue where attempting to use a password that starts with any of these characters (`= - + @`) fails with `Content cannot start with the following characters: = - + @` validation error. This adds a new validator to the Password Field called `noop` that skips validation. LDAP passwords do not need to be validated or checked against any local password policies as we are using an externally created password, not creating a new one inside the software.