### PR TITLE
audit: Use X-Forwarded-For Address

### DIFF
--- a/audit/class.audit.php
+++ b/audit/class.audit.php
@@ -708,7 +708,7 @@ class AuditEntry extends VerySimpleModel {
         }
 
         $event->event_id = $event_id;
-        $event->ip = $_SERVER['REMOTE_ADDR'];
+        $event->ip = osTicket::get_client_ip();
 
         if ($thisstaff)
             $event->staff_id = $thisstaff->getId();


### PR DESCRIPTION
This addresses issue reported at osTicket/osTicket/issues/5315 where the Audit Log plugin uses the REMOTE_ADDR header for the IP Address for some log entries which can be incorrect in some cases. A good case would be a reverse proxy, the `REMOTE_ADDR` header will be the IP Address of the Proxy and not the original Client’s IP. In order to get the actual Client IP Address from a proxied request you need to scan the request for the `X-Forwarded-For` header. osTicket already has function to accomplish this called `get_client_ip()`. This updates `audit/class.audit.php` to use `get_client_ip()` instead of the `REMOTE_ADDR` header which should return the actual Client IP Address.