### PR TITLE
audit: New Agent DB Error

### DIFF
--- a/audit/templates/agent-audit.tmpl.php
+++ b/audit/templates/agent-audit.tmpl.php
@@ -3,11 +3,13 @@ $args = array();
 parse_str($_SERVER['QUERY_STRING'], $args);
 unset($args['p'], $args['_pjax']);
 
-$events = AuditEntry::getTableInfo($staff);
-$total = count($events);
-$qwhere = AuditEntry::getQwhere($staff);
-$pageNav=AuditEntry::getPageNav($qwhere);
-$pageNav->setURL('staff.php', $args);
+if ($staffId = $staff->getId()) {
+    $events = AuditEntry::getTableInfo($staff);
+    $total = count($events);
+    $qwhere = AuditEntry::getQwhere($staff);
+    $pageNav=AuditEntry::getPageNav($qwhere);
+    $pageNav->setURL('staff.php', $args);
+}
 
  ?>
 <h3><?php echo __('Agent Audit History'); ?></h3>
@@ -40,7 +42,7 @@ $pageNav->setURL('staff.php', $args);
 
         <?php
         foreach ($events as $data) { ?>
-          <tr data-staff-id="<?php echo $staff->getId(); ?>">
+          <tr data-staff-id="<?php echo $staffId; ?>">
               <td><?php echo $data['description']; ?></td>
               <td><?php echo $data['timestamp']; ?></td>
               <td><?php echo $data['ip']; ?></td>
@@ -56,9 +58,9 @@ $pageNav->setURL('staff.php', $args);
 <hr/>
 <?php
     echo '<div>';
-    echo '&nbsp;'.__('Page').':'.$pageNav->getPageLinks('audits').'&nbsp;';
+    if ($staffId) echo '&nbsp;'.__('Page').':'.$pageNav->getPageLinks('audits').'&nbsp;';
     echo sprintf('<a href="ajax.php/audit/export/sid,%d" id="%s" class="no-pjax nomodalexport">%s</a>',
-        $staff->getId(),
+        $staffId,
         'audit-export',
         __('Export'));
     echo '</div>';


### PR DESCRIPTION
This addresses an issue where having the Audit Log plugin Enabled and creating a new Agent throws a DB Error 1064. This error is due to an incomplete Staff object (as it's being created) which causes issues in later methods. This adds a check for a Staff ID and if none we avoid running the Audit queries.