### PR TITLE
add hCaptcha field

### DIFF
--- a/field-hcaptcha/config.php
+++ b/field-hcaptcha/config.php
@@ -1,0 +1,38 @@
+<?php
+
+class hCaptchaConfig extends PluginConfig {
+    function getOptions() {
+        return array(
+            '_' => new SectionBreakField(array(
+                'label' => 'hCaptcha Configuration',
+                'hint' => 'Requires separate registration for a key set'
+            )),
+            'siteKey' => new TextboxField(array(
+                'required' => true,
+                'configuration'=>array('length'=>36, 'size'=>40),
+                'label' => 'Site Key',
+            )),
+            'secretKey' => new TextboxField(array(
+                'widget' => 'PasswordWidget',
+                'required' => false,
+                'configuration'=>array('length'=>42, 'size'=>40),
+                'label' => 'Secret Key',
+            )),
+        );
+    }
+
+    function pre_save($config, &$errors) {
+        // Todo: verify key
+
+        if (!function_exists('curl_init')) {
+            Messages::error('CURL extension is required');
+            return false;
+        }
+
+        global $msg;
+        if (!$errors)
+            $msg = 'Successfully updated hCaptcha settings';
+
+        return true;
+    }
+}

--- a/field-hcaptcha/field.php
+++ b/field-hcaptcha/field.php
@@ -136,7 +136,7 @@ class hCaptchaField extends FormField {
       hCaptchaField::$plugin_config = $this->getConfig();
       FormField::addFieldTypes(__('Verification'), function() {
         return array(
-          'hCaptcha' => array('Cloudflare hCaptcha', 'hCaptchaField')
+          'hCaptcha' => array('hCaptcha', 'hCaptchaField')
         );
       });
     }

--- a/field-hcaptcha/field.php
+++ b/field-hcaptcha/field.php
@@ -1,0 +1,143 @@
+<?php
+
+require_once INCLUDE_DIR . 'class.dynamic_forms.php';
+require_once INCLUDE_DIR . 'class.forms.php';
+
+class hCaptchaField extends FormField {
+  static $widget = 'hCaptchaWidget';
+  static $plugin_config;
+
+  function getPluginConfig() {
+    return static::$plugin_config;
+  }
+
+  function validateEntry($value) {
+    static $validation = array();
+
+    parent::validateEntry($value);
+    // ValidateEntry may be called twice, which is a problem
+    $id = $this->get('id');
+    $config = $this->getPluginConfig()->getInfo();
+    if (!isset($validation[$id])) {
+      list($code, $json) = $this->http_post(
+        ' https://hcaptcha.com/siteverify ',
+        array(
+          'secret' => $config['secretKey'],
+          'response' => $value,
+          'remoteip' => $_SERVER['REMOTE_ADDR'],
+        ));
+        if ($code !== 200) {
+          $response = array(
+            'error-codes' => array('no-response'),
+          );
+        } else {
+          $response = JsonDataParser::decode($json);
+        }
+        $I = &$validation[$id];
+        if (!($I['valid'] = $response['success'])) {
+          $errors = array();
+          foreach ($response['error-codes'] as $code) {
+            switch ($code) {
+              case 'missing-input-response':
+                $errors[] = sprintf(__('%s is a required field'),
+                $this->getLabel() ?: __('This'));
+              break;
+              case 'invalid-input-response':
+                $errors[] = "Your response doesn't look right. Please try again";
+              break;
+              case 'no-response':
+                $errors[] = "Unable to communicate with the hCaptcha server";
+            }
+          }
+          $I['errors'] = $errors;
+        }
+      }
+      if (!$validation[$id]['valid']) {
+        foreach ($validation[$id]['errors'] as $e) {
+          $this->_errors[] = $e;
+        }
+      }
+    }
+
+    protected function http_post($url, array $data) {
+      $ch = curl_init();
+      curl_setopt($ch, CURLOPT_URL, $url);
+      curl_setopt($ch, CURLOPT_USERAGENT, 'osTicket/'.THIS_VERSION);
+      curl_setopt($ch, CURLOPT_HEADER, FALSE);
+      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, FALSE);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+      curl_setopt($ch, CURLOPT_POST, 1);
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+      if (isset($_SERVER['HTTPS_PROXY']))
+      curl_setopt($ch, CURLOPT_PROXY, $_SERVER['HTTPS_PROXY']);
+
+      $result=curl_exec($ch);
+      $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+      curl_close($ch);
+
+      return array($code, $result);
+    }
+
+    function getConfigurationOptions() {
+      return array(
+        'theme' => new ChoiceField(array(
+          'label' => 'hCaptcha Theme',
+          'choices' => array('dark' => 'Dark', 'light' => 'Light'),
+          'default' => 'light',
+        )),
+        'size' => new ChoiceField(array(
+          'label' => 'hCaptcha Size',
+          'choices' => array('compact' => 'Compact', 'normal' => 'Normal'),
+          'default' => 'normal',
+        )),
+      );
+    }
+
+    function getMedia() {
+      return array(
+        'js' => array(
+          '//hcaptcha.com/1/api.js?hl='
+            . Internationalization::getCurrentLanguage()
+        ),
+      );
+    }
+  }
+
+  class hCaptchaWidget extends Widget {
+    function render() {
+      $fconfig = $this->field->getConfiguration();
+      $pconfig = $this->field->getPluginConfig()->getInfo();
+      ?>
+      <div class="h-captcha"
+      data-sitekey="<?php echo $pconfig['siteKey']; ?>"
+      data-theme="<?php echo $fconfig['theme'] ?: 'light'; ?>"
+      data-size="<?php echo $fconfig['size'] ?: 'normal'; ?>"
+      ></div>
+      <?php
+    }
+
+    function getValue() {
+      if (!($data = $this->field->getSource()))
+        return null;
+
+      if (!isset($data['h-captcha-response']))
+        return null;
+
+      return $data['h-captcha-response'];
+    }
+  }
+
+  require_once 'config.php';
+
+  class hCaptchaPlugin extends Plugin {
+    var $config_class = 'hCaptchaConfig';
+
+    function bootstrap() {
+      hCaptchaField::$plugin_config = $this->getConfig();
+      FormField::addFieldTypes(__('Verification'), function() {
+        return array(
+          'hCaptcha' => array('Cloudflare hCaptcha', 'hCaptchaField')
+        );
+      });
+    }
+  }

--- a/field-hcaptcha/plugin.php
+++ b/field-hcaptcha/plugin.php
@@ -1,0 +1,12 @@
+<?php
+
+return array(
+    'id' =>             'field:hCaptcha', # notrans
+    'version' =>        '0.1',
+    'name' =>           'Cloudflare hCaptcha field',
+    'author' =>         'Niko',
+    'description' =>    'Provides a hCaptcha field. This will help verify humans for both new
+    tickets by guests as well as client registration. Loosely based on the reCaptcha Plugin by Jared',
+    'url' =>            'http://www.osticket.com/plugins/field/hcaptcha',
+    'plugin' =>         'field.php:hCaptchaPlugin',
+);

--- a/field-hcaptcha/plugin.php
+++ b/field-hcaptcha/plugin.php
@@ -3,7 +3,7 @@
 return array(
     'id' =>             'field:hCaptcha', # notrans
     'version' =>        '0.1',
-    'name' =>           'Cloudflare hCaptcha field',
+    'name' =>           'hCaptcha field',
     'author' =>         'Niko',
     'description' =>    'Provides a hCaptcha field. This will help verify humans for both new
     tickets by guests as well as client registration. Loosely based on the reCaptcha Plugin by Jared',


### PR DESCRIPTION
Based on the reCaptcha plugin @greezybacon made a while back.
hCaptcha is what Cloudflare has moved to since they finally understood the privacy concerns with using a Google Service for captchas.
They produced a nice article about it and the motivations behind it:
https://blog.cloudflare.com/moving-from-recaptcha-to-hcaptcha/

Another benefit over reCaptcha is that you can actually earn money by letting your customers do "human aided image recognition and classification"

Tested with osTicket v1.12.x

Since the workflow is almost identical to reCaptcha, the configuration and implementation stays the same.
First, configure Site Key and Secret Key
![image](https://user-images.githubusercontent.com/3878282/80067041-a74b3300-852c-11ea-817a-f3975f39a798.png)


Add the field, set type and set mandatory
![image](https://user-images.githubusercontent.com/3878282/80067047-aa462380-852c-11ea-87cf-87e211907b3f.png)

It supports a light and a dark theme and two sizes
![image](https://user-images.githubusercontent.com/3878282/80067118-cc3fa600-852c-11ea-875b-043ee6f9c3b2.png)

This is how it looks, it selects the localized version based on the osTicket language for the user
![image](https://user-images.githubusercontent.com/3878282/80067141-d661a480-852c-11ea-99ba-5876cf314169.png)
