### PR TITLE
Attachments in Amazon S3: Folders

### DIFF
--- a/storage-s3/config.php
+++ b/storage-s3/config.php
@@ -23,6 +23,10 @@ class S3StoragePluginConfig extends PluginConfig {
                 'label' => $__('S3 Bucket'),
                 'configuration' => array('size'=>40),
             )),
+            'folder' => new TextboxField(array(
+                'label' => $__('S3 Folder Path'),
+                'configuration' => array('size'=>40),
+            )),
             'aws-region' => new ChoiceField(array(
                 'label' => $__('AWS Region'),
                 'choices' => array(

--- a/storage-s3/storage.php
+++ b/storage-s3/storage.php
@@ -54,7 +54,7 @@ class S3StorageBackend extends FileStorageBackend {
             return $chunk;
         }
         catch (Aws\S3\Exception\NoSuchKeyException $e) {
-            throw new IOException($this->meta->getKey()
+            throw new IOException(self::getKey()
                 .': Unable to locate file: '.(string)$e);
         }
     }
@@ -63,12 +63,12 @@ class S3StorageBackend extends FileStorageBackend {
         try {
             $res = $this->client->getObject(array(
                 'Bucket' => static::$config['bucket'],
-                'Key' => $this->meta->getKey(),
+                'Key'    => self::getKey(),
             ));
             fpassthru($res['Body']);
         }
         catch (Aws\S3\Exception\NoSuchKeyException $e) {
-            throw new IOException($this->meta->getKey()
+            throw new IOException(self::getKey()
                 .': Unable to locate file: '.(string)$e);
         }
     }
@@ -109,7 +109,7 @@ class S3StorageBackend extends FileStorageBackend {
 
             $info = $this->client->upload(
                 static::$config['bucket'],
-                $this->meta->getKey(),
+                self::getKey(),
                 $filepath,
                 static::$config['acl'] ?: 'private',
                 array('params' => $params)
@@ -140,7 +140,7 @@ class S3StorageBackend extends FileStorageBackend {
         $now = time();
         Http::redirect($this->client->getObjectUrl(
             static::$config['bucket'],
-            $this->meta->getKey(),
+            self::getKey(),
             $now + 86400 - ($now % 86400), # Expire at midnight
             array(
                 'ResponseContentDisposition' => sprintf("%s; %s;",
@@ -154,7 +154,7 @@ class S3StorageBackend extends FileStorageBackend {
         try {
             $this->client->deleteObject(array(
                 'Bucket' => static::$config['bucket'],
-                'Key' => $this->meta->getKey()
+                'Key'    => self::getKey()
             ));
             return true;
         }
@@ -192,7 +192,7 @@ class S3StorageBackend extends FileStorageBackend {
     protected function openReadStream() {
         $params = array(
             'Bucket' => static::$config['bucket'],
-            'Key' => $this->meta->getKey(),
+            'Key'    => self::getKey(),
         );
 
         // Create the command and serialize the request
@@ -216,6 +216,14 @@ class S3StorageBackend extends FileStorageBackend {
      */
     protected function openWriteStream() {
         $this->body = new EntityBody(fopen('php://temp', 'r+'));
+    }
+
+    function getKey() {
+        $key = static::$config['folder'] ?
+            sprintf('%s/%s', static::$config['folder'], $this->meta->getKey()) :
+            $this->meta->getKey();
+
+        return $key;
     }
 }
 


### PR DESCRIPTION
This commit adds a new field to the plugin configuration that allows the Admin to put in an S3 Folder Path if they want to upload files to a specific S3 folder. If no folder is provided, the file will be uploaded directly to the S3 Bucket. If a folder is specified and it does not currently exist in S3, the folder will be created.