### PR TITLE
Fix "name : Does not match the regex pattern"

### DIFF
--- a/make.php
+++ b/make.php
@@ -662,7 +662,7 @@ class PluginBuilder extends Module {
         // Write composer.json file
         $composer = <<<EOF
 {
-    "name": "osTicket/core-plugins",
+    "name": "osticket/core-plugins",
     "repositories": [
         {
             "type": "pear",


### PR DESCRIPTION
Needs to be lowercase. See https://stackoverflow.com/questions/63223402/composer-json-validation-error-for-regex-pattern-a-z0-9-a-z0-9-a/63225886#63225886 for more info.