### PR TITLE
Fix "pear-pear.php.net/Net_LDAP2 is invalid"

### DIFF
--- a/auth-ldap/plugin.php
+++ b/auth-ldap/plugin.php
@@ -11,10 +11,10 @@ return array(
     'url' =>            'http://www.osticket.com/plugins/auth/ldap',
     'plugin' =>         'authentication.php:LdapAuthPlugin',
     'requires' => array(
-        "pear-pear.php.net/Net_LDAP2" => array(
+        "pear-pear.php.net/net_ldap2" => array(
             "version" => "*",
             "map" => array(
-                'pear-pear.php.net/Net_LDAP2' => 'include',
+                'pear-pear.php.net/net_ldap2' => 'include',
             ),
         ),
     ),


### PR DESCRIPTION
> [RuntimeException]
> require.pear-pear.php.net/Net_LDAP2 is invalid, it should not contain uppercase characters. Please use pear-pear.php.net/net_ldap2 instead.