### PR TITLE
issue: Host/Port Int Vals

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -118,7 +118,7 @@ class LDAPAuthentication {
             $hosts = array();
             foreach ($servers as $h)
                 if (preg_match('/([^:]+):(\d{1,4})/', $h, $matches))
-                    $hosts[] = array('host' => $matches[1], 'port' => $matches[2]);
+                    $hosts[] = array('host' => $matches[1], 'port' => (int) $matches[2]);
                 else
                     $hosts[] = array('host' => $h);
             return $hosts;

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -159,7 +159,7 @@ class LdapConfig extends PluginConfig {
                 $servers = array();
                 foreach (preg_split('/\s+/', $config['servers']) as $host)
                     if (preg_match('/([^:]+):(\d{1,4})/', $host, $matches))
-                        $servers[] = array('host' => $matches[1], 'port' => $matches[2]);
+                        $servers[] = array('host' => $matches[1], 'port' => (int) $matches[2]);
                     else
                         $servers[] = array('host' => $host);
             }


### PR DESCRIPTION
This addresses an issue introduced with #162 where the port number is extracted from the Servers textbox but it is a string value instead of an int value. The `Net_LDAP2::__construct()` function expects the port number to be an integer so this casts the port number to an int.