### PR TITLE
Issue: Use Static Id

### DIFF
--- a/auth-2fa/auth2fa.php
+++ b/auth-2fa/auth2fa.php
@@ -24,11 +24,11 @@ class Auth2FAPlugin extends Plugin {
     }
 
     function disable() {
-        $default2fas = ConfigItem::getConfigsByNamespace(false, 'default_2fa', 'auth.agent');
+        $default2fas = ConfigItem::getConfigsByNamespace(false, 'default_2fa', static::$id);
         foreach($default2fas as $default2fa)
             $default2fa->delete();
 
-        $tokens = ConfigItem::getConfigsByNamespace(false, 'auth.agent');
+        $tokens = ConfigItem::getConfigsByNamespace(false, static::$id);
         foreach($tokens as $token)
             $token->delete();
 

--- a/auth-2fa/class.auth2fa.php
+++ b/auth-2fa/class.auth2fa.php
@@ -126,7 +126,7 @@ class Auth2FABackend extends TwoFactorAuthenticationBackend {
             $staff = Staff::lookup($s->getId());
         }
 
-        if (!$token = ConfigItem::getConfigsByNamespace('staff.'.$staff->getId(), 'auth.agent')) {
+        if (!$token = ConfigItem::getConfigsByNamespace('staff.'.$staff->getId(), static::$id)) {
             $auth2FA = new \Sonata\GoogleAuthenticator\GoogleAuthenticator();
             $this->secretKey = $auth2FA->generateSecret();
             $this->store($this->secretKey);


### PR DESCRIPTION
This commit makes sure we're using the defined static $id for the database key of the plugin.