### PR TITLE
Tweak Microsoft AD search in `auth-ldap`

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -38,7 +38,7 @@ class LDAPAuthentication {
                 'mobile' => false,
                 'username' => 'sAMAccountName',
                 'dn' => '{username}@{domain}',
-                'search' => '(&(objectCategory=person)(objectClass=user)(|(sAMAccountName={q}*)(firstName={q}*)(lastName={q}*)(displayName={q}*)))',
+                'search' => '(&(objectCategory=person)(objectClass=user)(|(sAMAccountName={q}*)(givenName={q}*)(sn={q}*)(displayName={q}*)(mail={q}*)))',
                 'lookup' => '(&(objectCategory=person)(objectClass=user)({attr}={q}))',
             ),
             'group' => array(


### PR DESCRIPTION
Currently search the `auth-ldap` plugin with Microsoft Active Directory connections only for *login name* and *display name*.

For first name (`givenName`) and last name (`sn`) was the wrong attributes used. I also added the mail address (`mail`) as addional search attribute.