### PR TITLE
Issue: 2FA URL Spaces/Special Chars

### DIFF
--- a/auth-2fa/auth2fa.php
+++ b/auth-2fa/auth2fa.php
@@ -8,6 +8,10 @@ class Auth2FAPlugin extends Plugin {
     var $config_class = "Auth2FAConfig";
 
     function bootstrap() {
+        $config = $this->getConfig();
+        if ($config->get('custom_issuer'))
+            Auth2FABackend::$custom_issuer = $config->get('custom_issuer');
+
         TwoFactorAuthenticationBackend::register('Auth2FABackend');
     }
 

--- a/auth-2fa/class.auth2fa.php
+++ b/auth-2fa/class.auth2fa.php
@@ -6,6 +6,7 @@ class Auth2FABackend extends TwoFactorAuthenticationBackend {
     static $name = "Authenticator";
 
     static $desc = /* @trans */ 'Verification codes are located in the Authenticator app of your choice on your phone';
+    static $custom_issuer;
 
     var $secretKey;
 
@@ -142,12 +143,11 @@ class Auth2FABackend extends TwoFactorAuthenticationBackend {
     }
 
     function getQRCode($staff=false) {
-        global $cfg;
-
         $staffEmail = $staff->getEmail();
         $secretKey = self::getSecretKey($staff);
+        $title = preg_replace('/[^A-Za-z0-9]/', '', self::$custom_issuer ?: __('osTicket'));
 
-        return \Sonata\GoogleAuthenticator\GoogleQrUrl::generate($staffEmail, $secretKey, $cfg->getTitle());
+        return \Sonata\GoogleAuthenticator\GoogleQrUrl::generate($staffEmail, $secretKey, $title);
     }
 
     function validateQRCode($staff=false) {

--- a/auth-2fa/config.php
+++ b/auth-2fa/config.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once INCLUDE_DIR . 'class.plugin.php';
+require_once INCLUDE_DIR.'class.forms.php';
 
 class Auth2FAConfig extends PluginConfig {
 
@@ -14,5 +15,23 @@ class Auth2FAConfig extends PluginConfig {
             );
         }
         return Plugin::translate('2fa-auth');
+    }
+
+    function getOptions() {
+        return array(
+            'custom_issuer' => new TextboxField(array(
+                'label' => __('Issuer'),
+                'required' => false,
+                'configuration' => array('size'=>40),
+                'hint' => __('Customize the Issuer shown in your Authenticator app after scanning a QR Code.'),
+            )),
+        );
+    }
+
+    function pre_save(&$config, &$errors) {
+        global $msg;
+        if (!$errors)
+            $msg = __('Configuration updated successfully');
+        return true;
     }
 }


### PR DESCRIPTION
This commit adds an option for an Admin to add a custom Issuer name in the Config for the 2FA plugin. The issuer is the title shown in an Authenticator app after the QR code is scanned. If no configuration is set up, we use 'osTicket' as the issuer name.

It also fixes an issue where some authenticators cannot handle spaces or special characters in the URL. It strips out spaces and special characters when generating the URL for the QR code.