### PR TITLE
Issue: Getting Agent/User Name

### DIFF
--- a/audit/class.audit.php
+++ b/audit/class.audit.php
@@ -746,7 +746,7 @@ class AuditEntry extends VerySimpleModel {
         if (is_object($object) && (get_class($object) == $data[0])) {
           switch ($abbrev) {
               case 'X':
-                  $data = array('person' => $thisstaff->getName()->name, 'key' => $info['key']);
+                  $data = array('person' => $thisstaff ? $thisstaff->getName()->name : __('SYSTEM'), 'key' => $info['key']);
                   $info['data'] = json_encode($data);
                   break;
               default:

--- a/audit/class.audit.php
+++ b/audit/class.audit.php
@@ -710,20 +710,23 @@ class AuditEntry extends VerySimpleModel {
         $event->event_id = $event_id;
         $event->ip = osTicket::get_client_ip();
 
-        if ($thisstaff)
-            $event->staff_id = $thisstaff->getId();
-        elseif (is_object($object) && get_class($object) == 'Staff')
-          $event->staff_id = $object->getId();
-        elseif (is_object($object) && get_class($object) == 'User')
-          $event->user_id = $object->getId();
-        elseif ($info['uid'])
-          $event->user_id = $info['uid'];
-        elseif ($thisclient)
-            $event->user_id = $thisclient->getId();
-        else
-          $event->user_id = $object->getUserId();
+        try {
+            if ($thisstaff)
+                $event->staff_id = $thisstaff->getId();
+            elseif (is_object($object) && get_class($object) == 'Staff')
+              $event->staff_id = $object->getId();
+            elseif (is_object($object) && get_class($object) == 'User')
+              $event->user_id = $object->getId();
+            elseif ($info['uid'])
+              $event->user_id = $info['uid'];
+            elseif ($thisclient)
+                $event->user_id = $thisclient->getId();
 
-        return $event->save();
+            return $event->save();
+        } catch (Exception $e) {
+            //TODO: Return an error message
+        }
+
     }
 
     static function auditSpecialEvent($object, $info=array()) {


### PR DESCRIPTION
This PR fixes an issue in the Audit Plugin in a scenario that if we could not retrieve the staff or user during checks, the default else statement was $object->getUserId(). In the event that the object did not have that method, for example, when running the cron job, the $object is ConfigItem, it resulted in a fatal error.

Additionally, it adds a commit that fixes an issue we had with the audit plugin assuming that any time the config table is being updated, it is by a signed in Agent.