### PR TITLE
storage-fs: mkdir Octal Numbers

### DIFF
--- a/storage-fs/storage.php
+++ b/storage-fs/storage.php
@@ -69,7 +69,7 @@ class FilesystemStorage extends FileStorageBackend {
         // Auto-create the subfolders
         $base .= '/'.$prefix;
         if (!is_dir($base))
-            mkdir($base, 751);
+            mkdir($base, 0751);
 
         return $base.'/'.$hash;
     }


### PR DESCRIPTION
This addresses issue #215 where the permissions for `mkdir()` need to be octal numbers. This updates the permissions from `751` to `0751`.