### PR TITLE
auth-ldap: Add configuration option for custom search filters

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -28,6 +28,7 @@ class LDAPAuthentication {
     static $schemas = array(
         'msad' => array(
             'user' => array(
+                'filter' => '(objectClass=user)',
                 'base' => 'CN=Users',
                 'first' => 'givenName',
                 'last' => 'sn',
@@ -37,6 +38,8 @@ class LDAPAuthentication {
                 'mobile' => false,
                 'username' => 'sAMAccountName',
                 'dn' => '{username}@{domain}',
+                'search' => '(&(objectCategory=person)(objectClass=user)(|(sAMAccountName={q}*)(firstName={q}*)(lastName={q}*)(displayName={q}*)))',
+                'lookup' => '(&(objectCategory=person)(objectClass=user)({attr}={q}))',
             ),
             'group' => array(
                 'ismember' => '(&(objectClass=user)(sAMAccountName={username})
@@ -47,6 +50,7 @@ class LDAPAuthentication {
         // A general approach for RFC-2307
         '2307' => array(
             'user' => array(
+                'filter' => '(objectClass=inetOrgPerson)',
                 'first' => 'gn',
                 'last' => 'sn',
                 'full' => array('displayName', 'gecos', 'cn'),
@@ -55,6 +59,8 @@ class LDAPAuthentication {
                 'mobile' => 'mobileTelephoneNumber',
                 'username' => 'uid',
                 'dn' => 'uid={username},{search_base}',
+                'search' => '(&(objectClass=inetOrgPerson)(|(uid={q}*)(displayName={q}*)(cn={q}*)))',
+                'lookup' => '(&(objectClass=inetOrgPerson)({attr}={q}))',
             ),
         ),
     );

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -228,11 +228,7 @@ class LDAPAuthentication {
         if (!$this->_bind($c))
             return null;
 
-        $auth_filter = $schema['lookup'];
-
-        if ($this->getConfig()->get('use_custom_filters')) {
-            $auth_filter = $this->getConfig()->get('auth_filter');
-        }
+        $auth_filter = $this->getConfig()->get('use_custom_filters')?($this->getConfig()->get('auth_filter')):($schema['lookup']);
 
         $r = $c->search(
             $this->getSearchBase(),
@@ -314,11 +310,8 @@ class LDAPAuthentication {
         $schema = static::$schemas[$this->getSchema($c)];
         $schema = $schema['user'];
 
-        $search_filter = $schema['search'];
+        $search_filter = ($this->getConfig()->get('use_custom_filters'))?($this->getConfig()->get('search_filter')):($schema['search']);
 
-        if ($this->getConfig()->get('use_custom_filters')) {
-            $search_filter = $this->getConfig()->get('search_filter');
-        }
         $r = $c->search(
             $this->getSearchBase(),
             str_replace('{q}', $query, $search_filter),

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -305,7 +305,7 @@ class LDAPAuthentication {
         $search_filter = $this->getConfig()->get('search_filter');
         $r = $c->search(
             $this->getSearchBase(),
-            str_replace('{q}', $query, $search_filter,
+            str_replace('{q}', $query, $search_filter),
             array('attributes' => array_filter(flatten(array(
                 $schema['first'], $schema['last'], $schema['full'],
                 $schema['phone'], $schema['mobile'], $schema['email'],

--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -228,7 +228,12 @@ class LDAPAuthentication {
         if (!$this->_bind($c))
             return null;
 
-        $auth_filter = $this->getConfig()->get('auth_filter');
+        $auth_filter = $schema['lookup'];
+
+        if ($this->getConfig()->get('use_custom_filters')) {
+            $auth_filter = $this->getConfig()->get('auth_filter');
+        }
+
         $r = $c->search(
             $this->getSearchBase(),
             str_replace(
@@ -308,7 +313,12 @@ class LDAPAuthentication {
 
         $schema = static::$schemas[$this->getSchema($c)];
         $schema = $schema['user'];
-        $search_filter = $this->getConfig()->get('search_filter');
+
+        $search_filter = $schema['search'];
+
+        if ($this->getConfig()->get('use_custom_filters')) {
+            $search_filter = $this->getConfig()->get('search_filter');
+        }
         $r = $c->search(
             $this->getSearchBase(),
             str_replace('{q}', $query, $search_filter),

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -106,6 +106,17 @@ class LdapConfig extends PluginConfig {
                     '2307' => 'Posix Account (rfc 2307)',
                 ),
             )),
+            'search_filter_options' => new SectionBreakField(array(
+                'label' => $__('Custom search filters'),
+                'hint' => $__('Custom search filter options in case the pre-supplied ones are non-sufficient.')
+            )),
+            'use_custom_filters' => new BooleanField(array(
+                'label' => $__('Use Custom Filters'),
+                'default' => false,
+                'configuration' => array(
+                    'desc' => $__('Use Custom Search and Authentication Filters')
+                )
+            )),
             'search_filter' => new TextboxField(array(
                 'label' => $__('LDAP Filter for searching users'),
                 'hint' => $__('Used when searching for users. {q} will be replaced with the search term.'),

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -108,11 +108,13 @@ class LdapConfig extends PluginConfig {
             )),
             'search_filter' => new TextboxField(array(
                 'label' => $__('LDAP Filter for searching users'),
-                'hint' => $__('Used when searching for users. {q} will be replaced with the search term.')
+                'hint' => $__('Used when searching for users. {q} will be replaced with the search term.'),
+                'configuration' => array('size'=>70, 'length'=>160),
             )),
             'auth_filter' => new TextboxField(array(
                 'label' => $__('LDAP Filter for authentication'),
-                'hint' => $__('Used when authenticating. {q} will be replaced with the user id.')
+                'hint' => $__('Used when authenticating. {q} will be replaced with the user id.'),
+                'configuration' => array('size'=>70, 'length'=>160),
             )),
 
             'auth' => new SectionBreakField(array(

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -106,6 +106,14 @@ class LdapConfig extends PluginConfig {
                     '2307' => 'Posix Account (rfc 2307)',
                 ),
             )),
+            'search_filter' => new TextboxField(array(
+                'label' => $__('LDAP Filter for searching users'),
+                'hint' => $__('Used when searching for users. {q} will be replaced with the search term.')
+            )),
+            'auth_filter' => new TextboxField(array(
+                'label' => $__('LDAP Filter for authentication'),
+                'hint' => $__('Used when authenticating. {q} will be replaced with the user id.')
+            )),
 
             'auth' => new SectionBreakField(array(
                 'label' => $__('Authentication Modes'),


### PR DESCRIPTION
So far there was no custom search filter option for LDAP.

This gives more control over how to search for users and agents to the administrator.

This also is referenced in a different pull request comment:

https://github.com/osTicket/osTicket-plugins/pull/213#issuecomment-941103588

