### PR TITLE
Update Google sign-in button asset URL

### DIFF
--- a/auth-oauth/google.php
+++ b/auth-oauth/google.php
@@ -32,7 +32,7 @@ class GoogleStaffAuthBackend extends ExternalStaffAuthenticationBackend {
     static $id = "google";
     static $name = "Google Plus";
 
-    static $sign_in_image_url = "https://developers.google.com/+/images/branding/sign-in-buttons/White-signin_Long_base_44dp.png";
+    static $sign_in_image_url = "https://developers.google.com/identity/images/btn_google_signin_light_normal_web.png";
     static $service_name = "Google+";
 
     var $config;


### PR DESCRIPTION
Google+ has been shelved. Assets related to it are no longer hosted. I lifted this asset URL from the branding guidelines page.

Google is not providing hosting for these assets. We should consider incorporating the provided static images into the plugin itself.