### PR TITLE
auth-password-policy: Cast expires to int

### DIFF
--- a/auth-password-policy/auth.php
+++ b/auth-password-policy/auth.php
@@ -68,7 +68,7 @@ extends PluginConfig {
                 'required' => false,
                 'label' => __('Password expiration'),
                 'choices' => array(
-                    ''  => __('Never expires'),
+                    '0'  => __('Never expires'),
                     '30' => __('30 days'),
                     '60' => __('60 days'),
                     '90' => __('90 days'),
@@ -101,9 +101,10 @@ extends PasswordPolicy {
             $this->processPassword($password);
 
         // Check password expiration
-        if ($this->config->get('expires')
+        $expires = (int) $this->config->get('expires', 0);
+        if ($expires
                 && ($time = $user->getPasswdResetTimestamp())
-                && ($time < (time()-($this->config->get('expires')*86400))))
+                && ($time < (time() - ($expires * 86400))))
             throw new ExpiredPassword(__('Expired Password'));
     }
 


### PR DESCRIPTION
This PR addresses an issue where password expiration check failed in v1.17.x due to `Uncaught TypeErro`r caused by changing how config data is stored (type casted JSON store to general config store).  Days to expiration (expires) needed to be casted to int.