### PR TITLE
hydrate: Support Expanded Matching for files/directories

### DIFF
--- a/make.php
+++ b/make.php
@@ -495,6 +495,15 @@ class PluginBuilder extends Module {
             copy($left, $right);
             return;
         }
+
+        // See if we need to do filtering via expandable search
+        if (preg_match('/{+(.*?)}/', $source)) {
+            foreach (glob($source, GLOB_BRACE) as $_source)
+                $this->mapDependencies($options, $lib, $local, $_source,
+                 ($dest.'/'.basename($_source)));
+            return;
+        }
+
         foreach (
             $iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),

--- a/storage-s3/plugin.php
+++ b/storage-s3/plugin.php
@@ -11,7 +11,7 @@ return array(
         "aws/aws-sdk-php" => array(
             'version' => "3.*",
             'map' => array(
-                'aws/aws-sdk-php/src' => 'lib/Aws',
+                'aws/aws-sdk-php/src/{S3*,*.php}' => 'lib/Aws',
                 'guzzlehttp/guzzle/src' => 'lib/GuzzleHttp',
                 'guzzlehttp/promises/src' => 'lib/GuzzleHttp/Promise',
                 'guzzlehttp/psr7/src/' => 'lib/GuzzleHttp/Psr7',


### PR DESCRIPTION
This PR adds support for expanded matching when hydrating libraries. This allows us to only pick part of the library or sdk we need to make the plugin functional without any extra packages.

PS: GLOB_BRACE flag used for expanded search is not available on some non GNU systems, like Solaris or Alpine Linux.