### PR TITLE
MS OAuth2: Don't force consent prompt

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -637,7 +637,6 @@ class MicrosoftEmailOauth2Provider extends GenericEmailOauth2Provider {
     static $urlOptions = [
         'tenant' => 'common',
         'accessType' => 'offline_access',
-        'prompt' => 'consent',
         ];
 }
 ?>


### PR DESCRIPTION
Microsoft OAuth2 endpoints are smart enough that we don't need to tell it to issue a consent prompt.

In a number of cases (I tested this with two separate differently configured differently-secured tenants on MS365 today), defining `'prompt' => 'consent'` as one of the url options will force **admin consent** (this is translated to `admin_consent` on the MS365 backend - figured out after a 3 hour power session with MS365 admins and support who discovered this).

When you send the OAuth request to MS365, the system is smart enough to determine if you need consent or not, and you do **NOT** need to tell MS365 that a consent window is required.  That may be a requisite for other providers, but not MS365 based on the testing I've done, and what MS365 support said on the 3 hour power-session support call.