### PR TITLE
fix File not found Aws/data/manifest.json

### DIFF
--- a/storage-s3/plugin.php
+++ b/storage-s3/plugin.php
@@ -13,7 +13,7 @@ return array(
             'version' => "3.*",
             'map' => array(
                 'aws/aws-sdk-php/src/{Api*,Arn*,ClientSideMonitoring*,Credentials*,DefaultsMode*,Endpoint*,Exception*,Handler*,Retry*,S3*,Signature*,*.php}' => 'lib/Aws',
-                'aws/aws-sdk-php/src/data' => 'lib/Aws',
+                'aws/aws-sdk-php/src/data' => 'lib/Aws/data',
                 'guzzlehttp/guzzle/src' => 'lib/GuzzleHttp',
                 'guzzlehttp/promises/src' => 'lib/GuzzleHttp/Promise',
                 'guzzlehttp/psr7/src/' => 'lib/GuzzleHttp/Psr7',


### PR DESCRIPTION
When saving the credentials after installing the latest storage-s3 plugin in osTicket 1.17 it failed to save giving the error 
> File not found: phar:///var/www/html/include/plugins/storage-s3.phar/lib/Aws/data/manifest.json

I have tracked the problem to pull request [#23](https://github.com/osTicket/osTicket-plugins/pull/238) and this pull request was enough to fix it.