### PR TITLE
auth-oauth2: Disable Strict Email Matching on Authorization

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -64,6 +64,10 @@ trait OAuth2AuthenticationTrait {
     private $provider;
     // debug mode flag
     private $debug = false;
+    // Strict flag
+    // TODO: Make it configurable (checkbox)
+    private $strict = false;
+
     // SESSION store for data like AuthNRequestID
     private $session;
     // Configuration store
@@ -103,6 +107,10 @@ trait OAuth2AuthenticationTrait {
         } catch (Exception $ex) {
             return false;
         }
+    }
+
+    private function isStrict() {
+        return (bool) $this->strict;
     }
 
     function getId() {
@@ -302,9 +310,10 @@ class OAuth2EmailAuthBackend implements OAuth2AuthBackend  {
                     'resource_owner_id' => $token->getResourceOwnerId(),
                     'resource_owner_email' => $attrs['email'],
                 ];
+
                 if (!isset($attrs['email']))
                     $errors[$err] = $this->error_msg(self::ERR_EMAIL_ATTR, $attrs);
-                elseif (!$this->signIn($attrs))
+                elseif ($this->isStrict() && !$this->signIn($attrs))
                     $errors[$err] = $this->error_msg(self::ERR_EMAIL_MISMATCH, $attrs);
                 elseif (!$info['refresh_token'])
                     $errors[$err] = $this->error_msg(self::ERR_REFRESH_TOKEN);


### PR DESCRIPTION
This PR disables strict email match when doing email authorization (getting token). While strict by default was noble, checking for a match is troublesome when a global admin can authorize for an email account or/and its aliases.

A strict placeholder flag is set to false default for now with the intention of making it configurable in the future.