### PR TITLE
Issue: Decrease S3 Plugin Size

### DIFF
--- a/storage-s3/plugin.php
+++ b/storage-s3/plugin.php
@@ -12,8 +12,7 @@ return array(
         "aws/aws-sdk-php" => array(
             'version' => "3.*",
             'map' => array(
-                'aws/aws-sdk-php/src/{Api*,Arn*,ClientSideMonitoring*,Credentials*,DefaultsMode*,Endpoint*,Exception*,Handler*,Retry*,S3*,Signature*,*.php}' => 'lib/Aws',
-                'aws/aws-sdk-php/src/data' => 'lib/Aws',
+                'aws/aws-sdk-php/src' => 'lib/Aws',
                 'guzzlehttp/guzzle/src' => 'lib/GuzzleHttp',
                 'guzzlehttp/promises/src' => 'lib/GuzzleHttp/Promise',
                 'guzzlehttp/psr7/src/' => 'lib/GuzzleHttp/Psr7',
@@ -23,6 +22,12 @@ return array(
                 'psr/http-message/src' => 'lib/Psr/Http/Message',
             ),
         ),
+    ),
+    'scripts' =>  array(
+        'pre-autoload-dump' => 'Aws\\Script\\Composer\\Composer::removeUnusedServices',
+    ),
+    'extra' => array(
+        'aws/aws-sdk-php' => 'S3',
     ),
     'plugin' =>         'storage.php:S3StoragePlugin'
 );


### PR DESCRIPTION
This commit reduces the size of the S3 plugin by only pulling files needed to use S3 in the AWS SDK.

This is done by following the steps outlined here: 

```
https://github.com/stobrien89/aws-sdk-php/tree/remove-unused-services/src/Script/Composer
```