### PR TITLE
ldap: Staff Authentication Backend ID

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -440,7 +440,7 @@ class StaffLDAPAuthentication extends StaffAuthenticationBackend
         $hit =  $this->_ldap->lookup($dn);
         if ($hit) {
             $hit['backend'] = static::$id;
-            $hit['id'] = static::$id . ':' . $hit['dn'];
+            $hit['id'] = $this->getBkId() . ':' . $hit['dn'];
         }
         return $hit;
     }
@@ -452,7 +452,7 @@ class StaffLDAPAuthentication extends StaffAuthenticationBackend
         $hits = $this->_ldap->search($query);
         foreach ($hits as &$h) {
             $h['backend'] = static::$id;
-            $h['id'] = static::$id . ':' . $h['dn'];
+            $h['id'] = $this->getBkId() . ':' . $h['dn'];
         }
         return $hits;
     }


### PR DESCRIPTION
This addresses an issue where we are still using the static ID instead of using the Backend ID causing Agent lookups and searches to fail. This updates both places we use the static ID to `getBkId()` instead. This will retrieve the proper Backend ID and will allow Agent lookups and searches to function successfully.