### PR TITLE
oauth2: User/Agent Destination Url

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -222,7 +222,7 @@ implements OAuth2AuthBackend  {
     }
 
     private function onSignIn() {
-        $this->redirectTo(osTicket::get_base_url().'scp/');
+        $this->redirectTo($_SESSION['_staff']['auth']['dest'] ?: osTicket::get_base_url().'scp/');
     }
 
 }
@@ -258,7 +258,7 @@ implements OAuth2AuthBackend {
     }
 
     private function onSignIn() {
-        $this->redirectTo(osTicket::get_base_url());
+        $this->redirectTo($_SESSION['_client']['auth']['dest'] ?: osTicket::get_base_url());
     }
 }
 


### PR DESCRIPTION
This addresses an issue reported on the Forum where you click a direct link from an email or something, you hit the login page, you login via OAuth2 SSO, and when you are redirected back you are not presented with the original URL. This is due to not accounting for the destination URL in the `onSignIn()` methods for the OAuth2 User/Agent backends. This adds a ternary statement that uses the dest URL from the session, otherwise it defaults to the base URL.