### PR TITLE
ldap: No current() Fatal Error

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -386,7 +386,7 @@ class LDAPAuthentication {
                     $this->getSearchBase(),
                     sprintf('(|(userPrincipalName=%s)(samAccountName=%s))', $dn, $samid),
                     $opts);
-                if (!PEAR::isError($r) && $r->count())
+                if (!PEAR::isError($r) && $r->count() && $r->current())
                     $dn = $r->current()->dn();
             }
 


### PR DESCRIPTION
This addresses an issue where `msad` schemas can return `false` when calling `current()` on an LDAP search result. We do not check if `current()` is false before attempting to call `dn()` on it so this adds a check to see if `current()` returns a value before using it.