### PR TITLE
Fixed issue for Microsoft 365 Shared Mailboxes.

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -323,7 +323,14 @@ class OAuth2EmailAuthBackend implements OAuth2AuthBackend  {
                     if ($this->isStrict())
                         $errors[$err] = $this->error_msg(self::ERR_EMAIL_MISMATCH, $attrs);
                     else
-                        $info['resource_owner_email'] = $this->getEmailAddress();
+                        // In Microsoft 365 you MUST send emails from a licenced User Mailbox,
+                        // if this is a Shared Mailbox the emails need to be collected from the
+                        // Shared Mailbox, but need to be sent from a User Mailbox.
+                        // This is typically the account you will authenticate with in the
+                        // Microsoft 365 challenge when configuring OAuth2 for the mailbox.
+                        if (!(strcasecmp(($this->account->getType()), "smtp") == 0)
+                                && !(strcasecmp(($this->account->getProtocol()), "smtp") == 0))
+                            $info['resource_owner_email'] = $this->getEmailAddress();
                 }
 
                 // Update the credentials if no validation errors


### PR DESCRIPTION
Fixed issue for Microsoft 365 Shared Mailboxes.

This issue has been discussed in the following forum post
https://forum.osticket.com/d/101462-oauth2-shared-mailboxes/34 

This push fixes and resolves the issue so that the **`resource_owner_email`** is set correctly as the **Shared Mailbox** email on the **_Remote Mailbox_** tab and the **User Mailbox / Global Admin** is set on the **_Outgoing (SMTP)_** tab.

The logic for this is

- To pickup emails you need to use the email address of the account that emails were sent to, this can either be a **User Mailbox** or a **Shared Mailbox**.
- To send emails a **_Licenced Microsoft 365 User Mailbox_** must be used, so the emails are sent from the **User Mailbox** account that is used to authenticate the **Shared Mailbox** or the actual **User Mailbox** on the Microsoft 365 OAuth2 challenge.

If using Shared Mailboxes, the User Mailbox account that is used to send emails is often referred to as a **Service Account** or a **Global Admin** account.
This account needs to have permissions to be able to access and send emails on behalf of the Shared Mailbox(es) that you configure on your osTicket configuration.