### PR TITLE
Microsoft OAuth2 - Consent Prompt Option

### DIFF
--- a/auth-oauth2/config.php
+++ b/auth-oauth2/config.php
@@ -58,6 +58,10 @@ class OAuth2Config extends PluginConfig {
         return $this->get("attr_$name", $default);
     }
 
+    public function getOAuth2ConsentPrompt() {
+        return $this->get('oauth2_consent_prompt');
+    }
+
     public function getClientSettings() {
         $scopes =  $this->getScopes();
         $settings = [
@@ -294,6 +298,12 @@ class OAuth2Config extends PluginConfig {
                     'length' => 0
                 ),
             )),
+            'oauth2_consent_prompt' => new BooleanField(array(
+                    'required' => false,
+                    'default'=>false,
+                    'configuration'=>array(
+                        'desc' => __('Require an OAuth2 Admin Consent Window'))
+            )),
         );
     }
 
@@ -308,7 +318,7 @@ class OAuth2Config extends PluginConfig {
                 // Authorization fields
                 $base =  array_flip(['idp', 'auth_type', 'redirectUri', 'clientId', 'clientSecret',
                         'urlAuthorize', 'urlAccessToken',
-                        'urlResourceOwnerDetails', 'scopes', 'attr_email',
+                        'urlResourceOwnerDetails', 'scopes', 'attr_email', 'oauth2_consent_prompt',
                 ]);
                 $fields = array_merge($base, array_intersect_key(
                             $this->getAllOptions(), $base));

--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -341,6 +341,10 @@ class OAuth2EmailAuthBackend implements OAuth2AuthBackend  {
     public function triggerAuth() {
         // Regenerate OAuth2 auth request
         $urlOptions = $this->provider->getUrlOptions() ?: [];
+        // If Admin Consent is required add it to the urlOptions array.
+        if ($this->config->getOAuth2ConsentPrompt()){
+            $urlOptions = array_merge($urlOptions, ['prompt' => 'consent']);
+        }
         $authUrl = $this->client->getAuthorizationUrl($urlOptions);
         // Get the state generated for you and store it to the session.
         $this->setState($this->client->getState());


### PR DESCRIPTION
**Microsoft OAuth2 - Consent Prompt Option**

This provides the option for the user to either enable or disable a consent prompt from Microsoft when authorising the OAuth2 request with Microsoft 365.

This was discussed as a possible option in Pull Request #241, this provides that option to the end user when configuring the OAuth2 endpoint.
The default behaviour is disabled so will not cause any issues to existing systems if it is not configured.

The new option is shown in the **IdP Config** tab in the OAuth2 Authorisation popup.