### PR TITLE
Microsoft OAuth2 - Strict Email Match Option

### DIFF
--- a/auth-oauth2/config.php
+++ b/auth-oauth2/config.php
@@ -58,6 +58,10 @@ class OAuth2Config extends PluginConfig {
         return $this->get("attr_$name", $default);
     }
 
+    public function getOAuth2StrictMode() {
+        return $this->get('oauth2_strict_mode');
+    }
+
     public function getClientSettings() {
         $scopes =  $this->getScopes();
         $settings = [
@@ -294,6 +298,12 @@ class OAuth2Config extends PluginConfig {
                     'length' => 0
                 ),
             )),
+            'oauth2_strict_mode' => new BooleanField(array(
+                    'required' => false,
+                    'default'=>false,
+                    'configuration'=>array(
+                        'desc' => __('Enable OAuth2 Strict Email Matching'))
+            )),
         );
     }
 
@@ -308,7 +318,7 @@ class OAuth2Config extends PluginConfig {
                 // Authorization fields
                 $base =  array_flip(['idp', 'auth_type', 'redirectUri', 'clientId', 'clientSecret',
                         'urlAuthorize', 'urlAccessToken',
-                        'urlResourceOwnerDetails', 'scopes', 'attr_email',
+                        'urlResourceOwnerDetails', 'scopes', 'attr_email', 'oauth2_strict_mode',
                 ]);
                 $fields = array_merge($base, array_intersect_key(
                             $this->getAllOptions(), $base));

--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -64,9 +64,6 @@ trait OAuth2AuthenticationTrait {
     private $provider;
     // debug mode flag
     private $debug = false;
-    // Strict flag
-    // TODO: Make it configurable (checkbox)
-    private $strict = false;
 
     // SESSION store for data like AuthNRequestID
     private $session;
@@ -110,7 +107,7 @@ trait OAuth2AuthenticationTrait {
     }
 
     private function isStrict() {
-        return (bool) $this->strict;
+        return (bool) $this->config->getOAuth2StrictMode();
     }
 
     function getId() {


### PR DESCRIPTION
**Microsoft OAuth2 - Strict Email Match Option**

This provides the option for the user to either enable or disable strict email matching rather than having it hard coded in the plugin.

- When enabled the email address configured in osTicket must match the account authorising the OAuth2 request.
- When disabled the email address cab be authorised by a User Mailbox that has permissions to send and receive on behalf of the email address configured in osTicket, this is a requirement for Shared Mailboxes to be able to send emails as they must be sent from a licenced user.

The fix for Shared Mailboxes in Microsoft 365 is in Merge Request #261.

The new option is shown in the **IdP Config** tab in the OAuth2 Authorisation popup.