### PR TITLE
auth-oauth2: Update Refresh Token

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -465,9 +465,11 @@ abstract class OAuth2ProviderBackend extends OAuth2AuthorizationBackend {
 
         try {
             $token = $bk->refreshAccessToken($refreshToken);
-            return [
-                'access_token' => $token->getToken(),
-                'expires' => $token->getExpires()];
+            return array_filter([
+		'access_token' => $token->getToken(),
+		'refresh_token' => $token->getRefreshToken(),
+		'expires' => $token->getExpires()
+	    ]);
         } catch( Exception $ex) {
             $errors['refresh_token'] = $ex->getMessage();
         }


### PR DESCRIPTION
This PR addresses an issue where Refresh Token expires after 90 days for users using Office 365 as the OAuth2 provider.

It turns out Microsoft (Office 365) issues a new Refresh Token everytime Access Token is refreshed [1], otherwise the original Refresh Token expires after 90 days from the time it was issued.

[1] - https://learn.microsoft.com/en-us/azure/active-directory/develop/refresh-tokens