### PR TITLE
issue: resolveDependencies Scripts and Extra

### DIFF
--- a/make.php
+++ b/make.php
@@ -677,12 +677,18 @@ class PluginBuilder extends Module {
 
     function resolveDependencies($autoupdate=true) {
         // Build dependency list
-        $requires = array();
+        $requires = $scripts = $extra = [];
         foreach (glob(dirname(__file__).'/*/plugin.php') as $plugin) {
             $p = (include $plugin);
             if (isset($p['requires']))
                 foreach ($p['requires'] as $lib=>$info)
                     $requires[$lib] = $info['version'];
+            if (isset($p['scripts']))
+                foreach ($p['scripts'] as $name=>$script)
+                    $scripts[$name] = $script;
+            if (isset($p['extra']))
+                foreach ($p['extra'] as $package=>$namespaces)
+                    $extra[$package] = $namespaces;
         }
 
         // Write composer.json file
@@ -692,10 +698,12 @@ class PluginBuilder extends Module {
     "require": %s,
     "config": {
         "vendor-dir": "lib"
-    }
+    },
+    "scripts": %s,
+    "extra": %s
 }
 EOF;
-        $composer = sprintf($composer, json_encode($requires));
+        $composer = sprintf($composer, json_encode($requires), json_encode($scripts), json_encode($extra));
 
         if (!($fp = fopen('composer.json', 'w')))
             $this->fail('Unable to save "composer.json"');

--- a/storage-s3/plugin.php
+++ b/storage-s3/plugin.php
@@ -27,7 +27,7 @@ return array(
         'pre-autoload-dump' => 'Aws\\Script\\Composer\\Composer::removeUnusedServices',
     ),
     'extra' => array(
-        'aws/aws-sdk-php' => 'S3',
+        'aws/aws-sdk-php' => ['S3'],
     ),
     'plugin' =>         'storage.php:S3StoragePlugin'
 );


### PR DESCRIPTION
This resolves and issue where when hydrating the S3 plugin it's still including uneeded dependencies even though the plugin info includes the script and extra tags. This is due to `make.php` not taking those into account when resolving the dependencies. This updates the `resolveDependencies` method to account for the scripts and extra tags and will include them if found.