### PR TITLE
audit: i18n Export Issues

### DIFF
--- a/audit/class.audit.php
+++ b/audit/class.audit.php
@@ -433,7 +433,7 @@ class AuditEntry extends VerySimpleModel {
           $qwhere.=' AND object_type='.db_input($_REQUEST['type'] ?: 'D');
           if ($hide_views)
             $qwhere.=' AND event_id='.db_input(Event::getIdByName($_REQUEST['state']));
-          if ($_REQUEST['state'] && $_REQUEST['state'] != __('All')) {
+          if ($_REQUEST['state'] && $_REQUEST['state'] != 'All') {
               $event_id = Event::getIdByName(lcfirst($_REQUEST['state']));
               $qwhere.=' AND event_id='.db_input($event_id);
           }

--- a/audit/templates/auditlogs.tmpl.php
+++ b/audit/templates/auditlogs.tmpl.php
@@ -11,7 +11,7 @@ if ($_REQUEST['type'])
 
 if($_REQUEST['state'])
     $qs += array('state' => Format::htmlchars($_REQUEST['state']));
-$state=__('All');
+$state='All';
 
 if ($_REQUEST['state'])
   $state=Format::htmlchars($_REQUEST['state']);


### PR DESCRIPTION
This is the second part to the main core pull that fixes an issue where using any other language than English and attempting to export `All` events for a specific object fails. This removes the translation method from the instances that do not need it and cause issues.