### PR TITLE
ldap: PHP 8.1 Support

### DIFF
--- a/lib/pear-pear.php.net/net_ldap2/Net/LDAP2/Entry.php
+++ b/lib/pear-pear.php.net/net_ldap2/Net/LDAP2/Entry.php
@@ -151,7 +151,7 @@ class Net_LDAP2_Entry extends PEAR
         parent::__construct('Net_LDAP2_Error');
 
         // set up entry resource or DN
-        if (is_resource($entry)) {
+        if ($entry !== false) {
             $this->_entry = $entry;
         } else {
             $this->_dn = $entry;
@@ -161,7 +161,7 @@ class Net_LDAP2_Entry extends PEAR
         if ($ldap instanceof Net_LDAP2) {
             $this->_ldap = $ldap;
             $this->_link = $ldap->getLink();
-        } elseif (is_resource($ldap)) {
+        } elseif ($ldap !== false) {
             $this->_link = $ldap;
         } elseif (is_array($ldap)) {
             // Special case: here $ldap is an array of attributes,
@@ -173,7 +173,7 @@ class Net_LDAP2_Entry extends PEAR
 
         // if this is an entry existing in the directory,
         // then set up as old and fetch attrs
-        if (is_resource($this->_entry) && is_resource($this->_link)) {
+        if (($this->_entry !== false) && ($this->_link !== false)) {
             $this->_new = false;
             $this->_dn  = @ldap_get_dn($this->_link, $this->_entry);
             $this->setAttributes();  // fetch attributes from server
@@ -235,7 +235,7 @@ class Net_LDAP2_Entry extends PEAR
         if (!$ldap instanceof Net_LDAP2) {
             return PEAR::raiseError("Unable to create connected entry: Parameter \$ldap needs to be a Net_LDAP2 object!");
         }
-        if (!is_resource($entry)) {
+        if ($entry == false) {
             return PEAR::raiseError("Unable to create connected entry: Parameter \$entry needs to be a ldap entry resource!");
         }
 
@@ -354,7 +354,7 @@ class Net_LDAP2_Entry extends PEAR
         /*
         * fetch attributes from the server
         */
-        if (is_null($attributes) && is_resource($this->_entry) && is_resource($this->_link)) {
+        if (is_null($attributes) && ($this->_entry !== false) && ($this->_link !== false)) {
             // fetch schema
             if ($this->_ldap instanceof Net_LDAP2) {
                 $schema = $this->_ldap->schema();
@@ -767,7 +767,7 @@ class Net_LDAP2_Entry extends PEAR
 
         // Get and check link
         $link = $ldap->getLink();
-        if (!is_resource($link)) {
+        if ($link == false) {
             return PEAR::raiseError("Could not update entry: internal LDAP link is invalid");
         }
 


### PR DESCRIPTION
This addresses PHP 8.1 compatibilty issues with the LDAP plugin. Since the LDAP resources were converted to LDAP\Connection, LDAP\Result, and LDAP\ResultEntry objects respectively, the previous `is_resource()` checks fail. This updates all relevant cases of `is_resource()` to `!== false` checks to make LDAP plugin compatible with PHP 8.1.