### PR TITLE
ldap: No current() Fatal Error 2

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -238,7 +238,7 @@ class LDAPAuthentication {
                 $schema['lookup']),
             array('sizelimit' => 1)
         );
-        if (PEAR::isError($r) || !$r->count())
+        if (PEAR::isError($r) || !$r->count() || !$r->current())
             return null;
 
         // Attempt to bind as the DN of the user looked up with the password


### PR DESCRIPTION
This addresses an error reported in #270 where we are attempting to call `dn()` on `$r->current()` but `current()` can sometimes return `false`. This adds a check for `!$r->current()` before continuing to `dn()`. See similar issue here: #260