### PR TITLE
Display account selection prompt for Microsoft 365 e-mail authentication

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -685,6 +685,7 @@ class MicrosoftEmailOauth2Provider extends GenericEmailOauth2Provider {
     static $urlOptions = [
         'tenant' => 'common',
         'accessType' => 'offline_access',
+        'prompt' => 'select_account',
         ];
 }
 ?>


### PR DESCRIPTION
Connecting a mailbox to Microsoft 365 with the OAuth2 plugin is difficult when you also use MS365 for authentication.

When trying to configure a mailbox, after filling in the authentication parameters and clicking on save, the app instantly redirects me to Microsoft 365 for logging in. Since I'm already logged into my personal MS365 account, it automatically gets a token for _that_ account. What I want instead is to log into a separate unmonitored e-mail account, created specifically for osTicket.

To fix this, I've added the `prompt=select_account` option to the `MicrosoftEmailOauth2Provider` class. As described in [the documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow), this will make Microsoft Login display an account selection prompt before returning the access token. Unlike the `prompt=consent` option (which was removed in https://github.com/osTicket/osTicket-plugins/pull/241), this will not automatically trigger an admin consent prompt.

This change should be unnoticeable for users who log in with username and passwords, and only use MS365 for e-mail sending; they'll just go through an additional screen when configuring a mailbox. For users who use MS365 for authentication, or who want to connect multiple MS365 accounts to the same osTicket instance, this change is essential. 