### PR TITLE
ldap: Hostname REGEX

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -117,8 +117,8 @@ class LDAPAuthentication {
         if ($servers) {
             $hosts = array();
             foreach ($servers as $h)
-                if (preg_match('/([^:]+):(\d{1,4})/', $h, $matches))
-                    $hosts[] = array('host' => $matches[1], 'port' => (int) $matches[2]);
+                if (preg_match('/((ldaps?:\/\/)?([^:]+)):(\d{1,4})/', $h, $matches))
+                    $hosts[] = array('host' => $matches[1], 'port' => (int) $matches[4]);
                 else
                     $hosts[] = array('host' => $h);
             return $hosts;

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -158,8 +158,8 @@ class LdapConfig extends PluginConfig {
             else {
                 $servers = array();
                 foreach (preg_split('/\s+/', $config['servers']) as $host)
-                    if (preg_match('/([^:]+):(\d{1,4})/', $host, $matches))
-                        $servers[] = array('host' => $matches[1], 'port' => (int) $matches[2]);
+                    if (preg_match('/((ldaps?:\/\/)?([^:]+)):(\d{1,4})/', $host, $matches))
+                        $servers[] = array('host' => $matches[1], 'port' => (int) $matches[4]);
                     else
                         $servers[] = array('host' => $host);
             }


### PR DESCRIPTION
This addresses an issue where `ldap://` and `ldaps://` gets stripped from the hostname by weak REGEX. This updates the REGEX to make it account for `ldap://` and `ldaps://` so that it remains as part of the hostname. This will allow people to typehint LDAPS connections.