### PR TITLE
Auth-2FA: Aesthetic correction of the 2FA code input field

### DIFF
--- a/auth-2fa/class.auth2fa.php
+++ b/auth-2fa/class.auth2fa.php
@@ -45,7 +45,8 @@ class Auth2FABackend extends TwoFactorAuthenticationBackend {
                 'validator'=>'number',
                 'hint'=>__('Please enter the code from your Authenticator app'),
                 'configuration'=>array(
-                    'size'=>40, 'length'=>40,
+                    'size'=>30,
+                    'length'=>12,
                     'autocomplete' => 'one-time-code',
                     'inputmode' => 'numeric',
                     'pattern' => '[0-9]*',

--- a/auth-2fa/plugin.php
+++ b/auth-2fa/plugin.php
@@ -2,11 +2,11 @@
 
 return array(
     'id' =>             '2fa:auth', # notrans
-    'version' =>        '0.3',
+    'version' =>        '0.3.1',
     'name' =>           /* trans */ 'Two Factor Authenticator',
     'author' =>         'Adriane Alexander',
-    'description' =>    /* trans */ 'Provides 2 Factor Authentication
-                        using an Authenticator App',
+    'contributor' =>    'Ezequiel Lage (@ezlage)',
+    'description' =>    /* trans */ 'Provides Two-Factor Authentication using an Authenticator App',
     'url' =>            'https://www.osticket.com/download',
     'plugin' =>         'auth2fa.php:Auth2FAPlugin',
     'requires' => array(


### PR DESCRIPTION
The size of the field previously caused it to be decentralized and exceeding the login box limits. Adjusted the size to 30 and the length to 12, in addition to updating the version and description of the plugin.