### PR TITLE
Add zimbra as ldap backend

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -63,6 +63,22 @@ class LDAPAuthentication {
                 'lookup' => '(&(objectClass=inetOrgPerson)({attr}={q}))',
             ),
         ),
+        // Zimbra LDAP is a bit different than standard ldap
+        'zimbra' => array(
+            'user' => array(
+                'filter' => '(objectClass=zimbraAccount)',
+                'first' => 'givenName',
+                'last' => 'sn',
+                'full' => array('displayName', 'cn'),
+                'email' => 'mail',
+                'phone' => 'telephoneNumber',
+                'mobile' => 'mobile',
+                'username' => 'uid',
+                'dn' => 'uid={username},{search_base}',
+                'search' => '(&(objectClass=zimbraAccount)(|(uid={q}*)(displayName={q}*)(cn={q}*)))',
+                'lookup' => '(&(objectClass=zimbraAccount)({attr}={q}))',
+            ),
+        ),
     );
 
     var $config;

--- a/auth-ldap/config.php
+++ b/auth-ldap/config.php
@@ -104,6 +104,7 @@ class LdapConfig extends PluginConfig {
                     'auto' => '— '.$__('Automatically Detect').' —',
                     'msad' => 'Microsoft® Active Directory',
                     '2307' => 'Posix Account (rfc 2307)',
+                    'zimbra' => 'Zimbra',
                 ),
             )),
 


### PR DESCRIPTION
This change adds "zimbra" as a an LDAP Schema because it uses different attributes compared to a regular ldap