### PR TITLE
ldap: Instance Name

### DIFF
--- a/auth-ldap/authentication.php
+++ b/auth-ldap/authentication.php
@@ -433,7 +433,7 @@ class StaffLDAPAuthentication extends StaffAuthenticationBackend
     function getName() {
         $config = $this->config;
         list($__, $_N) = $config->translate();
-        return $__(static::$name);
+        return $config->getName() ?: $__(static::$name);
     }
 
     function lookup($dn) {
@@ -472,7 +472,7 @@ class ClientLDAPAuthentication extends UserAuthenticationBackend {
     function getName() {
         $config = $this->config;
         list($__, $_N) = $config->translate();
-        return $__(static::$name);
+        return $config->getName() ?: $__(static::$name);
     }
 
     function authenticate($username, $password=false, $errors=array()) {


### PR DESCRIPTION
This addresses an issue where if you have more than one LDAP instance running it will show "Active Directory or LDAP" for all instances making it hard to differentiate the instances. This updates the `getName()` function to grab the name from the config if available otherwise defaults to the default name.