### PR TITLE
auth-oauth2: Add optional OIDC RP-Initiated Logout support

### DIFF
--- a/auth-oauth2/config.php
+++ b/auth-oauth2/config.php
@@ -54,6 +54,14 @@ class OAuth2Config extends PluginConfig {
         return $this->get('urlResourceOwnerDetails');
     }
 
+    public function getLogoutUrl() {
+        return $this->get('urlLogout');
+    }
+
+    public function getPostLogoutRedirectUri() {
+        return $this->get('urlPostLogout') ?: osTicket::get_base_url();
+    }
+
     public function getAttributeFor($name, $default=null) {
         return $this->get("attr_$name", $default);
     }
@@ -227,6 +235,46 @@ class OAuth2Config extends PluginConfig {
                         'length' => 0
                     ),
                     'default' => '',
+                )
+            ),
+            'logout_settings' => new SectionBreakField(array(
+                'label' => $__('Logout Settings'),
+                'hint' => $__('Optional OIDC RP-Initiated Logout configuration'),
+                'visibility' => new VisibilityConstraint(
+                    new Q(array('auth_type__eq' => 'auth')),
+                    VisibilityConstraint::HIDDEN
+                ),
+            )),
+            'urlLogout' => new TextboxField(
+                array(
+                    'label' => $__('Logout Endpoint'),
+                    'hint' => $__('OIDC end_session_endpoint. When set, users will be redirected here on logout to also end their IdP session (e.g. Keycloak: https://host/realms/{realm}/protocol/openid-connect/logout). Leave blank to disable IdP logout.'),
+                    'required' => false,
+                    'configuration' => array(
+                        'size' => 64,
+                        'length' => 0
+                    ),
+                    'default' => '',
+                    'visibility' => new VisibilityConstraint(
+                        new Q(array('auth_type__eq' => 'auth')),
+                        VisibilityConstraint::HIDDEN
+                    ),
+                )
+            ),
+            'urlPostLogout' => new TextboxField(
+                array(
+                    'label' => $__('Post-Logout Redirect URI'),
+                    'hint' => $__('Where to redirect after the IdP logout completes. Defaults to osTicket base URL if blank. Must be registered as an allowed post-logout redirect URI in your IdP client configuration.'),
+                    'required' => false,
+                    'configuration' => array(
+                        'size' => 64,
+                        'length' => 0
+                    ),
+                    'default' => '',
+                    'visibility' => new VisibilityConstraint(
+                        new Q(array('auth_type__eq' => 'auth')),
+                        VisibilityConstraint::HIDDEN
+                    ),
                 )
             ),
             'scopes' => new TextboxField(

--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -90,6 +90,12 @@ trait OAuth2AuthenticationTrait {
                 && ($token=$this->provider->getToken($resp['code']))
                 && ($attrs=$token->getOwnerAttributes())) {
                 $this->resetState();
+                // Store OIDC logout data for use by signOut
+                if (($idToken = $token->getIdToken()))
+                    $this->session['id_token'] = $idToken;
+                $this->session['logout_url']      = $this->config->getLogoutUrl();
+                $this->session['post_logout_uri'] = $this->config->getPostLogoutRedirectUri();
+                $this->session['client_id']       = $this->config->getClientId();
                 // Attempt to signIn the user based on returned attributes
                 $result = $this->signIn($attrs);
                 if ($result instanceof AuthenticatedUser) {
@@ -146,7 +152,28 @@ trait OAuth2AuthenticationTrait {
     }
 
     static function signOut($user) {
+        // Capture OIDC logout data before parent clears the session
+        $sess          = $_SESSION[':oauth'][static::$id] ?? [];
+        $idToken       = $sess['id_token']       ?? null;
+        $logoutUrl     = $sess['logout_url']     ?? null;
+        $postLogoutUri = $sess['post_logout_uri'] ?? null;
+        $clientId      = $sess['client_id']      ?? null;
+
+        // Clear local osTicket session (existing behaviour)
         parent::signOut($user);
+
+        // Clear OAuth session data
+        unset($_SESSION[':oauth'][static::$id]);
+
+        // Perform RP-Initiated Logout if an end_session_endpoint is configured
+        if ($logoutUrl) {
+            $params = array_filter([
+                'id_token_hint'            => $idToken,
+                'client_id'                => $clientId,
+                'post_logout_redirect_uri' => $postLogoutUri,
+            ]);
+            Http::redirect($logoutUrl . '?' . http_build_query($params));
+        }
     }
 
     abstract function signIn($attrs);
@@ -650,6 +677,11 @@ class Token extends AccessToken {
 
     protected function getUniqueName() {
         return $this->getJwt()->unique_name;
+    }
+
+    public function getIdToken() {
+        $values = $this->getValues();
+        return $values['id_token'] ?? null;
     }
 
     public function setOwner(Object $owner) {


### PR DESCRIPTION
## Summary

The `auth-oauth2` plugin currently only clears the local PHP session on
logout. For OIDC providers (e.g. Keycloak, Okta), the IdP session stays
alive — clicking login again silently re-authenticates the user without
any credential prompt.

This PR implements **RP-Initiated Logout** ([OIDC spec §5](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)):
after clearing the local session, the plugin redirects the browser to the
IdP's `end_session_endpoint` with `id_token_hint`, `client_id`, and
`post_logout_redirect_uri`. The IdP terminates its own session and
redirects the user back to osTicket.

## Changes

### `config.php`
- Added `getLogoutUrl()` and `getPostLogoutRedirectUri()` getters to `OAuth2Config`
- Added two optional fields to the plugin instance config UI (hidden for authorization-type instances):
  - **Logout Endpoint** (`urlLogout`) — the IdP's `end_session_endpoint`
  - **Post-Logout Redirect URI** (`urlPostLogout`) — where to land after IdP logout; defaults to the osTicket base URL

### `oauth2.php`
- Added `Token::getIdToken()` — extracts the OIDC `id_token` from the token response (stored automatically by the League OAuth2 client in `getValues()`)
- Updated `OAuth2AuthenticationTrait::callback()` — saves `id_token`, `logout_url`, `post_logout_uri`, and `client_id` into the existing `$_SESSION[':oauth'][{id}]` session namespace at login time
- Updated `OAuth2AuthenticationTrait::signOut()` — reads those values, calls `parent::signOut()` to clear the local session, then redirects to the IdP logout URL if one is configured

## Backward compatibility

The feature is **opt-in**: when `urlLogout` is left blank (the default for
all existing instances), `signOut()` behaves identically to before — only
the local session is cleared, no redirect occurs.

## Configuration (Keycloak example)

In the plugin instance settings, set:
- **Logout Endpoint**: `https://{keycloak-host}/realms/{realm}/protocol/openid-connect/logout`
- **Post-Logout Redirect URI**: `https://{osticket-host}/` *(must be registered as a valid post-logout redirect URI in the IdP client)*

Scopes must include `openid` so the IdP issues an `id_token` alongside the access token.