### PR TITLE
auth-oauth2: log callback failures to system logs

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -84,7 +84,7 @@ trait OAuth2AuthenticationTrait {
     }
 
     function callback($resp, $ref=null) {
-        //TODO: Log any errors to system logs
+        global $ost;
         try {
             if ($this->getState() == $resp['state']
                 && ($token=$this->provider->getToken($resp['code']))
@@ -97,9 +97,26 @@ trait OAuth2AuthenticationTrait {
                     // desired panel
                     if ($this->login($result, $this))
                         $this->onSignIn();
+                } elseif ($ost) {
+                    $ost->logWarning(sprintf('%s: Sign In Failed',
+                        $this->getServiceName()),
+                        'The identity provider returned valid attributes, '
+                        .'but no local account could be matched or '
+                        .'auto-registered for them.', false);
                 }
+            } elseif ($ost) {
+                $ost->logWarning(sprintf('%s: OAuth2 Callback Failed',
+                    $this->getServiceName()),
+                    'The OAuth2 callback did not complete: the state '
+                    .'parameter did not match, or the identity provider '
+                    .'did not return a usable access token / owner '
+                    .'attributes (e.g. invalid_client, invalid_grant, or '
+                    .'an expired authorization code).', false);
             }
         } catch (Exception $ex) {
+            if ($ost)
+                $ost->logError(sprintf('%s: OAuth2 Authentication Error',
+                    $this->getServiceName()), $ex->getMessage(), false);
             return false;
         }
     }


### PR DESCRIPTION
## Summary

`OAuth2AuthenticationTrait::callback()` has a `//TODO: Log any errors to system logs` comment that was never implemented, paired with a bare `catch (Exception $ex) { return false; }`. Every authentication failure in the OAuth2 callback flow — staff, end-user, and email-account variants all share this trait — is currently invisible to admins: nothing is written to the System Logs (`ost_syslog`), and the user/agent is just silently bounced back to the login screen.

This PR adds `$ost->logWarning()`/`logError()` calls on each failure branch. No behavior changes — return values are identical; this only adds diagnostics.

## Reproduction (currently silent)

1. Configure an OAuth2 IdP with an intentionally wrong client secret (or wait for a token to expire).
2. Attempt to sign in via OAuth2 as a staff or end user.
3. The IdP token exchange fails (e.g. `invalid_client`/`invalid_grant`), the `catch (Exception $ex)` swallows it, and the user is redirected back to login with no message.
4. Check Admin Panel → System Logs: nothing is recorded. There is no way for an admin to diagnose why authentication is failing.

A second silent path: the token exchange succeeds but `signIn()` can't match/auto-register the returned attributes to a local account (e.g. missing `username`/`email` claim from the IdP) — also currently unlogged.

## Test plan

- [ ] Configure OAuth2 with a bad client secret; confirm a `logWarning`/`logError` entry now appears in System Logs on failed callback.
- [ ] Successful login flow is unaffected (no new log entries, same redirect behavior).
- [ ] Confirm staff, end-user, and email-account OAuth2 backends (which all use `OAuth2AuthenticationTrait`) still authenticate correctly.