### PR TITLE
Add "Ticket Topic Approval" plugin

### DIFF
--- a/p-approvals/README.md
+++ b/p-approvals/README.md
@@ -1,0 +1,103 @@
+# Ticket Topic Approval (`p-approvals`)
+
+Holds tickets that are opened under a flagged Help Topic in a restricted
+department so they stay **invisible to every agent except the topic's designated
+approvers** until one of them approves or rejects the ticket.
+
+* The ticket **requester always sees their ticket normally** (the hold only
+  affects agents).
+* **Approve** → the ticket is moved back to the department it would normally
+  have landed in and becomes visible to all agents of that department.
+* **Reject** → an internal note with the reason is added and (by default) the
+  ticket is closed.
+
+## How the hiding works
+
+osTicket has no hook inside `Ticket::checkStaffPerm()`, so visibility is enforced
+natively: agents only see tickets in departments they have access to. On
+creation the plugin moves a pending ticket into a **holding department** whose
+only members are the approvers, and records the department the ticket should
+return to on approval (`ost_plugin_topic_approval`).
+
+> Note: osTicket administrators can still see every ticket regardless of
+> department. Approval is enforced for regular agents.
+
+## Install
+
+1. Copy this folder to `include/plugins/p-approvals` (already in place here via
+   the `./plugins` bind-mount).
+2. **Admin Panel → Agents → Departments → Add New Department**, e.g.
+   `Pending Approval`:
+   * do **not** add any members except the approvers;
+   * make sure it is **not** the *Primary Department* of any other agent and is
+     **not** granted through any Group's department access;
+   * set *Ticket Assignment* / alerts as you like.
+3. **Admin Panel → Manage → Plugins → Add New Plugin → Ticket Topic Approval →
+   Install**.
+4. Open the plugin, **Add New Instance**, and in the config:
+   * pick the **Pending Approval department** as the holding department;
+   * for every Help Topic that must be approved, select one or more
+     **approvers** (agents and/or teams). Topics left empty are ignored.
+   * enable the instance.
+
+## While a ticket is pending
+
+On the staff ticket view the plugin (via the `object.view` signal /
+`templates/ticket-guard.tmpl.php`):
+
+* shows a prominent **Approve / Decline** bar at the top;
+* forces the **Internal Note** tab and hides *Post Reply*, *Change Status*,
+  *reopen/close* and *Edit* – so agents can only add internal notes;
+* adds **“Approve with this note” / “Decline with this note”** buttons to the
+  Internal Note form, so a comment is posted together with the decision;
+* keeps the *Approve / Reject Ticket* item in the ⚙ *More* menu too.
+
+Each step is also written to the ticket **timeline as an event** (not just a
+note): *Held for topic approval*, *Topic approval granted by …*, *Topic approval
+rejected by …*. These are real `ThreadEvent` subclasses in `class.approval.php`;
+their state names are registered in `ost_event` by `ensureSchema()`.
+
+The decision endpoint (`ajax.php/p-approvals/<id>/decide`) always re-checks that
+the caller is an approver. The in-page hiding is a workflow convenience –
+real isolation comes from the holding department. Hard server-side blocking of
+replies/status changes would require patching osTicket core.
+
+## Email notifications
+
+Toggled in the plugin config (`notify-approvers`, `notify-requester`, both on by
+default) and rendered from **editable Email Templates** that the plugin registers
+in every template set (**Admin Panel → Emails → Templates**):
+
+| Code name | Section | Sent to | When |
+|---|---|---|---|
+| `approval.needed` | Ticket Agent Email Templates | each approver agent / team member | ticket held |
+| `approval.granted` | Ticket End-User Email Templates | requester | approved |
+| `approval.rejected` | Ticket End-User Email Templates | requester | rejected |
+
+Bodies are seeded once by `TopicApproval::ensureTemplates()`; edit them freely
+afterwards. Context vars: `ticket`, `recipient`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `plugin.php` | Manifest. |
+| `p-approvals.php` | `TopicApprovalPlugin` – signal wiring (`ticket.created`, `ticket.view.more`, `ajax.scp`, `object.view`). |
+| `config.php` | `TopicApprovalConfig` – dynamic per-topic approver matrix + toggles. |
+| `class.approval.php` | `TopicApproval` – persistence, approve/reject logic, thread events, email templates. |
+| `templates/decide.tmpl.php` | Approve / Reject dialog. |
+| `templates/ticket-guard.tmpl.php` | In-page workflow injected while a ticket is pending. |
+
+## Data
+
+Table `ost_plugin_topic_approval` (created automatically on bootstrap):
+`ticket_id` (PK), `topic_id`, `status` (`pending`/`approved`/`rejected`),
+`target_dept_id`, `requested_at`, `resolved_by`, `resolved_at`, `reason`.
+
+## Limitations
+
+* Changing a ticket's Help Topic *after* creation does not trigger the workflow.
+* The holding department's access configuration is a manual admin
+  responsibility (see Install step 2).
+* A custom signal `ticket.approved` is emitted on approval for further
+  extension.

--- a/p-approvals/class.approval.php
+++ b/p-approvals/class.approval.php
@@ -1,0 +1,487 @@
+<?php
+/**
+ * Domain logic + persistence for the Ticket Topic Approval plugin.
+ *
+ * A single row per pending/decided ticket is kept in
+ *   <prefix>plugin_topic_approval
+ * so we remember the department the ticket should land in once approved.
+ */
+require_once INCLUDE_DIR . 'class.thread.php';
+require_once INCLUDE_DIR . 'class.template.php';
+
+class TopicApproval {
+
+    const TABLE = 'plugin_topic_approval';
+
+    const STATUS_PENDING  = 'pending';
+    const STATUS_APPROVED = 'approved';
+    const STATUS_REJECTED = 'rejected';
+
+    /** @var TopicApprovalConfig set by the plugin on bootstrap */
+    static $config;
+
+    static function setConfig($config) {
+        self::$config = $config;
+    }
+
+    static function table() {
+        return TABLE_PREFIX . self::TABLE;
+    }
+
+    /* ---------------------------------------------------------------- schema */
+
+    static function ensureSchema() {
+        static $done = false;
+        if ($done)
+            return;
+        $done = true;
+
+        // Thread-event names so approvals show up as timeline events, not just notes.
+        db_query('INSERT IGNORE INTO ' . TABLE_PREFIX . "event (name) VALUES "
+            . "('approvalheld'),('approvalgranted'),('approvalrejected')");
+
+        $table = self::table();
+        $sql = "CREATE TABLE IF NOT EXISTS `$table` (
+            `ticket_id` int(11) unsigned NOT NULL,
+            `topic_id` int(11) unsigned NOT NULL DEFAULT 0,
+            `status` enum('pending','approved','rejected') NOT NULL DEFAULT 'pending',
+            `target_dept_id` int(11) unsigned NOT NULL DEFAULT 0,
+            `requested_at` datetime DEFAULT NULL,
+            `resolved_by` int(11) unsigned NOT NULL DEFAULT 0,
+            `resolved_at` datetime DEFAULT NULL,
+            `reason` text,
+            PRIMARY KEY (`ticket_id`),
+            KEY `status` (`status`)
+        ) DEFAULT CHARSET=utf8";
+        db_query($sql);
+    }
+
+    /* ---------------------------------------------------------------- config */
+
+    /**
+     * Normalise a stored config value into a flat list of selected keys.
+     *
+     * osTicket's ChoiceField (multiselect) stores its value as a JSON object
+     * {"key":"label", ...}; single ChoiceField stores {"key":"label"} too.
+     * Depending on when it is read it may already be decoded to an array.
+     */
+    static function selectedKeys($raw) {
+        if ($raw === null || $raw === '' || $raw === array())
+            return array();
+        // Already a scalar key (e.g. single ChoiceField decoded to its key).
+        if (is_int($raw) || is_bool($raw))
+            return array((string) $raw);
+        if (is_string($raw)) {
+            $trim = trim($raw);
+            if ($trim !== '' && $trim[0] !== '{' && $trim[0] !== '[')
+                return array_values(array_filter(array_map('trim', explode(',', $trim))));
+            $decoded = json_decode($trim, true);
+            if (!is_array($decoded))
+                return array();
+            $raw = $decoded;
+        }
+        if (!is_array($raw))
+            return array();
+        // Associative {key:label} -> keys; list [key,...] -> values.
+        $isAssoc = array_keys($raw) !== range(0, count($raw) - 1);
+        return array_values(array_filter($isAssoc ? array_keys($raw) : $raw,
+            function ($v) { return $v !== '' && $v !== null; }));
+    }
+
+    static function getHoldingDeptId() {
+        if (!self::$config)
+            return 0;
+        $keys = self::selectedKeys(self::$config->get('holding-dept'));
+        return $keys ? (int) reset($keys) : 0;
+    }
+
+    static function boolCfg($key, $default) {
+        if (!self::$config)
+            return $default;
+        $v = self::$config->get($key);
+        if ($v === null || $v === '')
+            return $default;
+        return !in_array(strtolower((string) $v), array('0', 'false', 'off', 'no'), true)
+            && (bool) $v;
+    }
+
+    static function notifyApprovers()     { return self::boolCfg('notify-approvers', true); }
+    static function notifyRequester()      { return self::boolCfg('notify-requester', true); }
+    static function rejectRequiresReason() { return self::boolCfg('reject-requires-reason', true); }
+    static function closeOnReject()        { return self::boolCfg('close-on-reject', true); }
+
+    /* ------------------------------------------------------------ email templates */
+
+    /**
+     * Editable Email Templates registered under Admin Panel > Emails > Templates.
+     * `subject`/`body` are seeded once into every template set by ensureTemplates().
+     */
+    static function templateDefs() {
+        return array(
+            'approval.needed' => array(
+                'group'   => 'b.ticket.staff',
+                'name'    => /* @trans */ 'Topic Approval - Needed (Agent)',
+                'desc'    => /* @trans */ 'Alert sent to the topic approvers when a ticket is held for approval.',
+                'context' => array('ticket', 'recipient'),
+                'subject' => 'Approval needed: Ticket #%{ticket.number}',
+                'body'    => '<p>Ticket <a href="%{ticket.staff_link}">#%{ticket.number}</a> '
+                    . '&mdash; <strong>%{ticket.subject}</strong> &mdash; was opened under a Help Topic '
+                    . 'that requires approval and is held in the <em>%{ticket.dept.name}</em> department '
+                    . 'until an approver releases it.</p>',
+            ),
+            'approval.granted' => array(
+                'group'   => 'a.ticket.user',
+                'name'    => /* @trans */ 'Topic Approval - Approved (User)',
+                'desc'    => /* @trans */ 'Notice sent to the requester when their ticket is approved.',
+                'context' => array('ticket', 'recipient'),
+                'subject' => 'Ticket #%{ticket.number} approved',
+                'body'    => '<p>Hi %{recipient.name.first},</p>'
+                    . '<p>Your ticket <strong>#%{ticket.number}</strong> &mdash; %{ticket.subject} &mdash; '
+                    . 'has been approved and is now being processed.</p>',
+            ),
+            'approval.rejected' => array(
+                'group'   => 'a.ticket.user',
+                'name'    => /* @trans */ 'Topic Approval - Rejected (User)',
+                'desc'    => /* @trans */ 'Notice sent to the requester when their ticket is rejected.',
+                'context' => array('ticket', 'recipient'),
+                'subject' => 'Ticket #%{ticket.number} rejected',
+                'body'    => '<p>Hi %{recipient.name.first},</p>'
+                    . '<p>Your ticket <strong>#%{ticket.number}</strong> &mdash; %{ticket.subject} &mdash; '
+                    . 'has been rejected.</p>',
+            ),
+        );
+    }
+
+    /** Make the templates visible/editable in the admin UI. Call from bootstrap. */
+    static function registerTemplates() {
+        if (!class_exists('EmailTemplateGroup'))
+            return;
+        foreach (self::templateDefs() as $cn => $d) {
+            EmailTemplateGroup::$all_names[$cn] = array(
+                'group'   => $d['group'],
+                'name'    => $d['name'],
+                'desc'    => $d['desc'],
+                'context' => $d['context'],
+            );
+        }
+    }
+
+    /** Seed the template bodies into each template set once. */
+    static function ensureTemplates() {
+        static $done = false;
+        if ($done)
+            return;
+        $done = true;
+
+        $tg  = TABLE_PREFIX . 'email_template_group';
+        $tt  = TABLE_PREFIX . 'email_template';
+        $defs = self::templateDefs();
+        $names = "'" . implode("','", array_map('addslashes', array_keys($defs))) . "'";
+
+        if (!($res = db_query('SELECT tpl_id FROM ' . $tg)))
+            return;
+        $groups = array();
+        while ($r = db_fetch_array($res))
+            $groups[] = (int) $r['tpl_id'];
+
+        // Fast path: every set already has every template.
+        $have = 0;
+        if ($c = db_query('SELECT COUNT(*) AS n FROM ' . $tt . ' WHERE code_name IN (' . $names . ')'))
+            $have = (int) (($row = db_fetch_array($c)) ? $row['n'] : 0);
+        if ($have >= count($groups) * count($defs))
+            return;
+
+        foreach ($groups as $gid) {
+            foreach ($defs as $cn => $d) {
+                $c = db_query('SELECT id FROM ' . $tt
+                    . ' WHERE tpl_id = ' . db_input($gid)
+                    . ' AND code_name = ' . db_input($cn));
+                if ($c && db_num_rows($c))
+                    continue;
+                db_query('INSERT INTO ' . $tt . ' SET created = NOW(), updated = NOW()'
+                    . ', tpl_id = ' . db_input($gid)
+                    . ', code_name = ' . db_input($cn)
+                    . ', subject = ' . db_input($d['subject'])
+                    . ', body = ' . db_input($d['body']));
+            }
+        }
+    }
+
+    /* ----------------------------------------------------------- notifications */
+
+    static function mailer($ticket) {
+        global $cfg;
+        if (($d = $ticket->getDept()) && ($e = $d->getEmail()))
+            return $e;
+        return $cfg ? $cfg->getDefaultEmail() : null;
+    }
+
+    static function templateGroup($ticket) {
+        global $cfg;
+        if (($d = $ticket->getDept()) && ($g = $d->getTemplate()))
+            return $g;
+        return $cfg ? $cfg->getDefaultTemplate() : null;
+    }
+
+    /** Render one of our Email Templates for $ticket; returns ['subj'=>, 'body'=>] or null. */
+    static function render($ticket, $codeName, $recipient, $extra = array()) {
+        if (!($group = self::templateGroup($ticket)))
+            return null;
+        if (!($tpl = $group->getMsgTemplate($codeName)))
+            return null;
+        return $ticket->replaceVars($tpl->asArray(),
+            array('recipient' => $recipient) + $extra);
+    }
+
+    /** Every approver agent + members of every approver team for a topic. */
+    static function collectApproverStaff($topicId) {
+        $staff = array();
+        foreach (self::getApproverSpec($topicId) as $token) {
+            $id = (int) substr($token, 1);
+            if ($token[0] === 's' && ($s = Staff::lookup($id)))
+                $staff[$s->getId()] = $s;
+            elseif ($token[0] === 't' && ($t = Team::lookup($id))) {
+                foreach ($t->getMembers() as $m)
+                    $staff[$m->getId()] = $m;
+            }
+        }
+        return $staff;
+    }
+
+    static function notifyApproversNeeded($ticket, $topicId) {
+        if (!self::notifyApprovers() || !($email = self::mailer($ticket)))
+            return;
+        foreach (self::collectApproverStaff($topicId) as $s) {
+            if (!$s->isAvailable())
+                continue;
+            if ($m = self::render($ticket, 'approval.needed', $s))
+                $email->sendAlert($s, $m['subj'], $m['body']);
+            else
+                $email->sendAlert($s,
+                    sprintf(__('Approval needed: Ticket #%s'), $ticket->getNumber()),
+                    sprintf(__('Ticket #%s needs topic approval.'), $ticket->getNumber()));
+        }
+    }
+
+    static function notifyRequesterDecision($ticket, $approved, $reason, Staff $by) {
+        if (!self::notifyRequester() || !($email = self::mailer($ticket)))
+            return;
+        if (!($owner = $ticket->getOwner()) || !$owner->getEmail())
+            return;
+        $code = $approved ? 'approval.granted' : 'approval.rejected';
+        if ($m = self::render($ticket, $code, $owner)) {
+            $email->send($owner, $m['subj'], $m['body']);
+            return;
+        }
+        $subject = $approved
+            ? sprintf(__('Ticket #%s approved'), $ticket->getNumber())
+            : sprintf(__('Ticket #%s rejected'), $ticket->getNumber());
+        $body = $approved
+            ? sprintf(__('Your ticket #%s has been approved.'), $ticket->getNumber())
+            : sprintf(__('Your ticket #%s has been rejected.'), $ticket->getNumber());
+        $email->send($owner, $subject, $body);
+    }
+
+    /**
+     * Raw approver tokens (s<id> / t<id>) configured for a topic.
+     */
+    static function getApproverSpec($topicId) {
+        if (!self::$config)
+            return array();
+        return self::selectedKeys(
+            self::$config->get(TopicApprovalConfig::TOPIC_FIELD_PREFIX . (int) $topicId));
+    }
+
+    static function requiresApproval($topicId) {
+        return (bool) self::getApproverSpec($topicId);
+    }
+
+    static function isApprover($topicId, $staff) {
+        if (!$staff instanceof Staff)
+            return false;
+        foreach (self::getApproverSpec($topicId) as $token) {
+            $kind = substr($token, 0, 1);
+            $id   = (int) substr($token, 1);
+            if ($kind === 's' && $id === (int) $staff->getId())
+                return true;
+            if ($kind === 't' && $staff->isTeamMember($id))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Human readable approver list for notes.
+     */
+    static function describeApprovers($topicId) {
+        $names = array();
+        foreach (self::getApproverSpec($topicId) as $token) {
+            $id = (int) substr($token, 1);
+            if ($token[0] === 's' && ($s = Staff::lookup($id)))
+                $names[] = $s->getName();
+            elseif ($token[0] === 't' && ($t = Team::lookup($id)))
+                $names[] = sprintf('%s (%s)', $t->getName(), __('team'));
+        }
+        return implode(', ', $names);
+    }
+
+    /* -------------------------------------------------------------- records */
+
+    static function getRecord($ticketId) {
+        $sql = 'SELECT * FROM ' . self::table()
+             . ' WHERE ticket_id = ' . db_input((int) $ticketId);
+        $res = db_query($sql);
+        return ($res && db_num_rows($res)) ? db_fetch_array($res) : null;
+    }
+
+    static function createPending($ticketId, $topicId, $targetDeptId) {
+        $sql = 'INSERT INTO ' . self::table()
+             . ' SET ticket_id = ' . db_input((int) $ticketId)
+             . ', topic_id = ' . db_input((int) $topicId)
+             . ', status = ' . db_input(self::STATUS_PENDING)
+             . ', target_dept_id = ' . db_input((int) $targetDeptId)
+             . ', requested_at = NOW()'
+             . ' ON DUPLICATE KEY UPDATE ticket_id = ticket_id';
+        return db_query($sql);
+    }
+
+    /* --------------------------------------------------------------- events */
+
+    /**
+     * Called from the ticket.created signal.
+     */
+    static function onTicketCreated($ticket) {
+        if (!$ticket instanceof Ticket)
+            return;
+
+        $topicId = $ticket->getTopicId();
+        if (!$topicId || !self::requiresApproval($topicId))
+            return;
+
+        // Already tracked (e.g. re-fired signal) -> nothing to do.
+        if (self::getRecord($ticket->getId()))
+            return;
+
+        $holding = self::getHoldingDeptId();
+        if (!$holding) {
+            error_log('[p-approvals] No holding department configured; ticket '
+                . $ticket->getId() . ' left in place.');
+            return;
+        }
+
+        $targetDept = (int) $ticket->getDeptId();
+        self::createPending($ticket->getId(), $topicId, $targetDept);
+
+        if ($holding !== $targetDept)
+            $ticket->setDeptId($holding);
+
+        $approvers = self::describeApprovers($topicId);
+        if ($approvers) {
+            $msg = sprintf(
+                __('This ticket was opened under a Help Topic that requires approval. '
+                 . 'It is held in the "%1$s" department and is not visible to other '
+                 . 'agents until it is approved. Approvers: %2$s.'),
+                Dept::getNameById($holding) ?: (string) $holding,
+                $approvers
+            );
+        } else {
+            $msg = __('This ticket requires approval but no approvers are configured. '
+                   . 'Please contact an administrator.');
+        }
+        $ticket->logNote(__('Awaiting topic approval'), $msg, 'SYSTEM', false);
+        $ticket->logEvent('approvalheld', array('topic' => $topicId), 'SYSTEM');
+
+        if ($approvers)
+            self::notifyApproversNeeded($ticket, $topicId);
+    }
+
+    static function approve($ticket, Staff $staff, $reason = '') {
+        $rec = self::getRecord($ticket->getId());
+        if (!$rec || $rec['status'] !== self::STATUS_PENDING)
+            return false;
+
+        $target = (int) $rec['target_dept_id'];
+        if ($target && $target !== (int) $ticket->getDeptId())
+            $ticket->setDeptId($target);
+
+        db_query('UPDATE ' . self::table()
+            . ' SET status = ' . db_input(self::STATUS_APPROVED)
+            . ', resolved_by = ' . db_input((int) $staff->getId())
+            . ', resolved_at = NOW()'
+            . ', reason = ' . db_input($reason)
+            . ' WHERE ticket_id = ' . db_input((int) $ticket->getId()));
+
+        $note = sprintf(__('Ticket approved by %s.'), (string) $staff->getName());
+        if ($reason)
+            $note .= "\n\n" . $reason;
+        $ticket->logNote(__('Topic approval: approved'), $note, $staff, true);
+        $ticket->logEvent('approvalgranted', array('reason' => $reason), $staff);
+        self::notifyRequesterDecision($ticket, true, $reason, $staff);
+
+        return true;
+    }
+
+    static function reject($ticket, Staff $staff, $reason = '') {
+        $rec = self::getRecord($ticket->getId());
+        if (!$rec || $rec['status'] !== self::STATUS_PENDING)
+            return false;
+
+        db_query('UPDATE ' . self::table()
+            . ' SET status = ' . db_input(self::STATUS_REJECTED)
+            . ', resolved_by = ' . db_input((int) $staff->getId())
+            . ', resolved_at = NOW()'
+            . ', reason = ' . db_input($reason)
+            . ' WHERE ticket_id = ' . db_input((int) $ticket->getId()));
+
+        $note = sprintf(__('Ticket rejected by %s.'), (string) $staff->getName());
+        if ($reason)
+            $note .= "\n\n" . $reason;
+        $ticket->logNote(__('Topic approval: rejected'), $note, $staff, true);
+        $ticket->logEvent('approvalrejected', array('reason' => $reason), $staff);
+        self::notifyRequesterDecision($ticket, false, $reason, $staff);
+
+        if (self::closeOnReject()) {
+            $errors = array();
+            if ($status = TicketStatus::lookup(array('state' => 'closed')))
+                $ticket->setStatus($status, $reason ?: __('Rejected by approver'), $errors);
+        }
+
+        return true;
+    }
+}
+
+/*
+ * Thread timeline events. osTicket's ThreadEvent::getTypedEvent() auto-discovers
+ * every ThreadEvent subclass by its static $state, so declaring these is enough
+ * for the entries logged via Ticket::logEvent('approval*') to render with their
+ * own wording and icon in the ticket history.
+ */
+class TopicApprovalHeldEvent extends ThreadEvent {
+    static $icon = 'lock';
+    static $state = 'approvalheld';
+    function getIcon() { return static::$icon; }
+    function getDescription($mode = self::MODE_STAFF) {
+        return $this->template(__('Held for topic approval {timestamp}'), $mode);
+    }
+}
+
+class TopicApprovalGrantedEvent extends ThreadEvent {
+    static $icon = 'ok-circle';
+    static $state = 'approvalgranted';
+    function getIcon() { return static::$icon; }
+    function getDescription($mode = self::MODE_STAFF) {
+        return $this->template(
+            __('Topic approval granted by <b>{somebody}</b> {timestamp}'), $mode);
+    }
+}
+
+class TopicApprovalRejectedEvent extends ThreadEvent {
+    static $icon = 'ban-circle';
+    static $state = 'approvalrejected';
+    function getIcon() { return static::$icon; }
+    function getDescription($mode = self::MODE_STAFF) {
+        return $this->template(
+            __('Topic approval rejected by <b>{somebody}</b> {timestamp}'), $mode);
+    }
+}
+?>

--- a/p-approvals/config.php
+++ b/p-approvals/config.php
@@ -1,0 +1,116 @@
+<?php
+require_once INCLUDE_DIR . 'class.plugin.php';
+
+/**
+ * Configuration for the Ticket Topic Approval plugin.
+ *
+ * The form is built dynamically: one multi-select per Help Topic listing every
+ * agent and every team. A topic with at least one selected approver becomes an
+ * "approval topic". Approver options are encoded as:
+ *   s<staff_id>   -> individual agent
+ *   t<team_id>    -> whole team
+ */
+class TopicApprovalConfig extends PluginConfig {
+
+    // Prefix for the per-topic approver fields.
+    const TOPIC_FIELD_PREFIX = 'approvers-';
+
+    function getOptions() {
+        // getOptions() runs on every request while the plugin instance is
+        // bootstrapped, which is *before* $cfg is initialized. Staff/Dept/Topic
+        // helpers dereference $cfg, so only build the dynamic choice lists once
+        // the app is far enough along to render/save the config form.
+        global $cfg;
+        $ready = ($cfg instanceof Config);
+
+        $depts = array('' => '— ' . __('Select a department') . ' —');
+        $approverChoices = array();
+        $topics = array();
+        if ($ready) {
+            try {
+                foreach (Dept::getDepartments() as $id => $name)
+                    $depts[$id] = $name;
+                foreach (Staff::getStaffMembers() as $sid => $sname)
+                    $approverChoices['s' . $sid] = sprintf('%s: %s', __('Agent'), $sname);
+                foreach (Team::getTeams() as $tid => $tname)
+                    $approverChoices['t' . $tid] = sprintf('%s: %s', __('Team'), $tname);
+                $topics = Topic::getHelpTopics(false, true);
+            } catch (Throwable $e) {
+                error_log('[p-approvals] getOptions: ' . $e->getMessage());
+            }
+        }
+
+        $options = array(
+            'general' => new SectionBreakField(array(
+                'label' => __('Holding department'),
+                'hint'  => __('Pending tickets are moved here. Give this department NO '
+                    . 'members other than the approvers (and make sure it is not any '
+                    . 'other agent\'s primary department and is not granted to groups), '
+                    . 'so unapproved tickets stay hidden from everyone else.'),
+            )),
+            'holding-dept' => new ChoiceField(array(
+                'label'   => __('Pending Approval department'),
+                'choices' => $depts,
+                'default' => '',
+                'hint'    => __('Required for the workflow to run.'),
+            )),
+            'behaviour' => new SectionBreakField(array(
+                'label' => __('Behaviour'),
+            )),
+            'notify-approvers' => new BooleanField(array(
+                'label'   => __('Email the approvers when a ticket needs approval'),
+                'default' => true,
+                'hint'    => __('Sends a direct alert to every approver agent and '
+                    . 'approver-team member for that topic.'),
+            )),
+            'notify-requester' => new BooleanField(array(
+                'label'   => __('Email the requester when the ticket is approved or rejected'),
+                'default' => true,
+            )),
+            'reject-requires-reason' => new BooleanField(array(
+                'label'   => __('Require a reason when rejecting'),
+                'default' => true,
+            )),
+            'close-on-reject' => new BooleanField(array(
+                'label'   => __('Close the ticket when rejected'),
+                'default' => true,
+                'hint'    => __('If unchecked, a rejected ticket stays open in the holding '
+                    . 'department with a note.'),
+            )),
+            'topics' => new SectionBreakField(array(
+                'label' => __('Approval topics'),
+                'hint'  => __('Pick the approvers for each Help Topic that must be approved. '
+                    . 'Leave a topic empty to exclude it from the workflow.'),
+            )),
+        );
+
+        foreach ($topics as $tid => $tname) {
+            $options[self::TOPIC_FIELD_PREFIX . $tid] = new ChoiceField(array(
+                'label'         => $tname,
+                'choices'       => $approverChoices,
+                'default'       => array(),
+                'configuration' => array('multiselect' => true),
+            ));
+        }
+
+        return $options;
+    }
+
+    function pre_save(&$config, &$errors) {
+        // A holding department is mandatory as soon as any topic has approvers.
+        $hasApprovalTopic = false;
+        foreach ($config as $key => $val) {
+            if (strpos($key, self::TOPIC_FIELD_PREFIX) === 0 && $val) {
+                $hasApprovalTopic = true;
+                break;
+            }
+        }
+        if ($hasApprovalTopic && empty($config['holding-dept'])) {
+            $errors['holding-dept'] = __('Select the Pending Approval department.');
+            $errors['err'] = __('A holding department is required when an approval topic is configured.');
+            return false;
+        }
+        return true;
+    }
+}
+?>

--- a/p-approvals/p-approvals.php
+++ b/p-approvals/p-approvals.php
@@ -1,0 +1,122 @@
+<?php
+require_once INCLUDE_DIR . 'class.signal.php';
+require_once INCLUDE_DIR . 'class.plugin.php';
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/class.approval.php';
+
+if (!defined('P_APPROVALS_DIR'))
+    define('P_APPROVALS_DIR', __DIR__ . '/');
+
+class TopicApprovalPlugin extends Plugin {
+
+    var $config_class = 'TopicApprovalConfig';
+
+    // One holding department / one approver matrix -> a single instance is enough.
+    function isMultiInstance() {
+        return false;
+    }
+
+    function bootstrap() {
+        TopicApproval::setConfig($this->getConfig());
+        TopicApproval::ensureSchema();
+        // Editable notification templates (Admin Panel > Emails > Templates).
+        TopicApproval::registerTemplates();
+        TopicApproval::ensureTemplates();
+
+        // 1) Hold freshly created tickets that belong to an approval topic.
+        Signal::connect('ticket.created', array('TopicApproval', 'onTicketCreated'));
+
+        // 2) Add "Approve / Reject" to the ticket action menu for approvers.
+        Signal::connect('ticket.view.more', array($this, 'onTicketViewMore'));
+
+        // 3) Register the decision endpoint on the staff ajax dispatcher.
+        Signal::connect('ajax.scp', array($this, 'onAjaxScp'));
+
+        // 4) While a ticket is pending: show the approval bar, force the
+        //    Internal Note tab and hide reply / status / edit actions.
+        Signal::connect('object.view', array($this, 'onObjectView'));
+    }
+
+    function onObjectView($object, $data = null) {
+        global $thisstaff, $cfg;
+        if (!$thisstaff || !$object instanceof Ticket)
+            return;
+
+        $rec = TopicApproval::getRecord($object->getId());
+        if (!$rec || $rec['status'] !== TopicApproval::STATUS_PENDING)
+            return;
+
+        $ticket      = $object;
+        $isApprover  = TopicApproval::isApprover($rec['topic_id'], $thisstaff);
+        $requireReason = TopicApproval::rejectRequiresReason();
+        $approvers   = TopicApproval::describeApprovers($rec['topic_id']);
+
+        include P_APPROVALS_DIR . 'templates/ticket-guard.tmpl.php';
+    }
+
+    function onTicketViewMore($ticket, &$extras) {
+        global $thisstaff;
+        if (!$thisstaff || !$ticket instanceof Ticket)
+            return;
+
+        $rec = TopicApproval::getRecord($ticket->getId());
+        if (!$rec || $rec['status'] !== TopicApproval::STATUS_PENDING)
+            return;
+        if (!TopicApproval::isApprover($rec['topic_id'], $thisstaff))
+            return;
+
+        $href = 'ajax.php/p-approvals/' . $ticket->getId() . '/decide';
+        echo sprintf(
+            '<li><a href="#%s" onclick="javascript:$.dialog($(this).attr(\'href\').substr(1)); return false;">'
+            . '<i class="icon-check"></i> %s</a></li>',
+            $href, __('Approve / Reject Ticket')
+        );
+    }
+
+    function onAjaxScp($dispatcher) {
+        $dispatcher->append(
+            url('^/p-approvals/(?P<tid>\d+)/decide$', function ($tid) {
+                global $thisstaff;
+
+                if (!$thisstaff)
+                    Http::response(403, 'Agent login required');
+
+                $ticket = Ticket::lookup((int) $tid);
+                if (!$ticket)
+                    Http::response(404, 'No such ticket');
+
+                $rec = TopicApproval::getRecord($ticket->getId());
+                if (!$rec || $rec['status'] !== TopicApproval::STATUS_PENDING)
+                    Http::response(404, 'Nothing to approve for this ticket');
+
+                if (!TopicApproval::isApprover($rec['topic_id'], $thisstaff))
+                    Http::response(403, 'You are not an approver for this topic');
+
+                $errors = array();
+                if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                    $decision = $_POST['decision'] ?? '';
+                    $reason   = trim($_POST['reason'] ?? '');
+
+                    if ($decision === 'approve') {
+                        TopicApproval::approve($ticket, $thisstaff, $reason);
+                        Http::response(201, json_encode(array(
+                            'redirect' => 'tickets.php?id=' . $ticket->getId())));
+                    } elseif ($decision === 'reject') {
+                        if (TopicApproval::rejectRequiresReason() && !$reason) {
+                            $errors['reason'] = __('A reason is required to reject.');
+                        } else {
+                            TopicApproval::reject($ticket, $thisstaff, $reason);
+                            Http::response(201, json_encode(array(
+                                'redirect' => 'tickets.php?id=' . $ticket->getId())));
+                        }
+                    } else {
+                        $errors['err'] = __('Choose approve or reject.');
+                    }
+                }
+
+                include P_APPROVALS_DIR . 'templates/decide.tmpl.php';
+            })
+        );
+    }
+}
+?>

--- a/p-approvals/plugin.php
+++ b/p-approvals/plugin.php
@@ -1,0 +1,13 @@
+<?php
+return array(
+    'id'          => 'ticket:topic-approval', # notrans
+    'version'     => '1.0.0',
+    'name'        => /* trans */ 'Ticket Topic Approval',
+    'author'      => 'steelants',
+    'description' => /* trans */ 'Tickets opened under a flagged Help Topic are held in a '
+        . 'restricted department and stay invisible to every agent except the topic\'s '
+        . 'designated approvers until one of them approves or rejects the ticket.',
+    'url'         => 'https://github.com/steelants/osTicket-plugins',
+    'plugin'      => 'p-approvals.php:TopicApprovalPlugin',
+);
+?>

--- a/p-approvals/templates/decide.tmpl.php
+++ b/p-approvals/templates/decide.tmpl.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Approve / Reject dialog for a pending ticket.
+ * Rendered inside the staff $.dialog() popup.
+ *
+ * Available: $ticket (Ticket), $rec (array row), $errors (array)
+ */
+if (!defined('INCLUDE_DIR')) die('Access Denied');
+$reason = Format::htmlchars($_POST['reason'] ?? '');
+$decision = $_POST['decision'] ?? 'approve';
+?>
+<h3 class="drag-handle"><?php echo sprintf(__('Approve ticket #%s'),
+    Format::htmlchars($ticket->getNumber())); ?></h3>
+<a class="close" href=""><i class="icon-remove-circle"></i></a>
+<hr/>
+<?php if ($errors) { ?>
+<div id="msg_error"><?php echo Format::htmlchars(implode(' ', $errors)); ?></div>
+<?php } ?>
+<form method="post" action="#p-approvals/<?php echo $ticket->getId(); ?>/decide">
+    <?php echo csrf_token(); ?>
+    <p><?php echo sprintf(__('Help Topic: %s'),
+        '<strong>' . Format::htmlchars(Topic::getLocalNameById($rec['topic_id'])) . '</strong>'); ?></p>
+    <table class="form_table" width="100%" cellpadding="2" cellspacing="0" border="0">
+        <tbody>
+            <tr>
+                <td width="120"><?php echo __('Decision'); ?>:</td>
+                <td>
+                    <label><input type="radio" name="decision" value="approve" <?php
+                        echo $decision === 'approve' ? 'checked' : ''; ?>>
+                        <?php echo __('Approve'); ?> &mdash;
+                        <?php echo __('move ticket to its normal department and make it visible'); ?></label><br/>
+                    <label><input type="radio" name="decision" value="reject" <?php
+                        echo $decision === 'reject' ? 'checked' : ''; ?>>
+                        <?php echo __('Reject'); ?></label>
+                </td>
+            </tr>
+            <tr>
+                <td valign="top"><?php echo __('Reason'); ?>:</td>
+                <td><textarea name="reason" rows="4" style="width:100%"
+                    class="<?php echo isset($errors['reason']) ? 'error' : ''; ?>"><?php
+                    echo $reason; ?></textarea>
+                    <?php if (isset($errors['reason'])) { ?>
+                    <div class="error"><?php echo Format::htmlchars($errors['reason']); ?></div>
+                    <?php } ?>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <hr/>
+    <p class="full-width">
+        <span class="buttons pull-left">
+            <input type="button" value="<?php echo __('Cancel'); ?>" class="close">
+        </span>
+        <span class="buttons pull-right">
+            <input type="submit" value="<?php echo __('Submit'); ?>">
+        </span>
+    </p>
+</form>

--- a/p-approvals/templates/ticket-guard.tmpl.php
+++ b/p-approvals/templates/ticket-guard.tmpl.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Injected on the staff ticket view while the ticket is pending topic approval.
+ *
+ * Available: $ticket, $rec, $isApprover (bool), $requireReason (bool), $approvers (string)
+ *
+ * The holding department is what actually hides the ticket from other agents;
+ * this layer is the in-page workflow: it forces "internal note only", hides the
+ * reply / status / edit affordances and gives approvers an Approve / Decline
+ * action (stand-alone banner + wired into the note form so a comment can be
+ * posted together with the decision).
+ */
+if (!defined('INCLUDE_DIR')) die('Access Denied');
+$tid = (int) $ticket->getId();
+?>
+<style>
+#p-approval-banner{margin:8px 0 12px;padding:10px 14px;border:1px solid #e0c000;
+  border-left:4px solid #e0c000;background:#fffaf0;border-radius:3px;
+  display:flex;align-items:center;gap:12px;flex-wrap:wrap;font-size:0.95em;}
+#p-approval-banner .p-msg{flex:1;min-width:220px;color:#7a5c00;}
+#p-approval-banner .buttons{white-space:nowrap;}
+#note .p-note-decide{display:inline;}
+#note .p-note-decide .button{margin-right:6px;}
+.p-decide-busy{opacity:.5;pointer-events:none;}
+</style>
+
+<div id="p-approval-banner">
+    <span class="p-msg">
+        <i class="icon-lock"></i>
+        <?php echo __('This ticket is awaiting topic approval and is hidden from other agents.'); ?>
+        <?php if ($approvers) echo ' ' . sprintf(__('Approvers: %s.'), Format::htmlchars($approvers)); ?>
+    </span>
+    <?php if ($isApprover) { ?>
+    <span class="buttons">
+        <button type="button" class="green button action-button" data-decision="approve">
+            <i class="icon-ok-sign"></i> <?php echo __('Approve'); ?></button>
+        <button type="button" class="red button action-button" data-decision="reject">
+            <i class="icon-ban-circle"></i> <?php echo __('Decline'); ?></button>
+    </span>
+    <?php } else { ?>
+    <span class="faded"><?php echo __('Only an approver can release this ticket.'); ?></span>
+    <?php } ?>
+</div>
+
+<script>
+(function boot(){
+  if (!window.jQuery){ return setTimeout(boot, 50); }
+  (function($){
+  var TID = <?php echo $tid; ?>,
+      IS_APPROVER = <?php echo $isApprover ? 'true' : 'false'; ?>,
+      REQUIRE_REASON = <?php echo $requireReason ? 'true' : 'false'; ?>,
+      MSG_REASON = <?php echo json_encode(__('Please add a note explaining the decision.')); ?>,
+      DECIDE_URL = 'ajax.php/p-approvals/' + TID + '/decide';
+
+  function csrf(){ return $('meta[name=csrf_token]').attr('content') || ''; }
+
+  function noteBody(){
+    var $ta = $('#internal_note');
+    if (!$ta.length) return '';
+    try { return $.trim($ta.redactor('code.get')); } catch(e){}
+    return $.trim($ta.val() || '');
+  }
+
+  function decideButtons(){ return $('#p-approval-banner .buttons, #note .p-note-decide'); }
+
+  function submitDecision(decision, reason){
+    if (decision === 'reject' && REQUIRE_REASON && !reason){
+      alert(MSG_REASON); return;
+    }
+    decideButtons().addClass('p-decide-busy');
+    $.ajax({
+      url: DECIDE_URL, type: 'POST',
+      data: { decision: decision, reason: reason || '' },
+      headers: { 'X-CSRFToken': csrf() },
+      success: function(resp){
+        try { var j = JSON.parse(resp); if (j && j.redirect){ window.location.href = j.redirect; return; } } catch(e){}
+        window.location.reload();
+      },
+      error: function(xhr){
+        decideButtons().removeClass('p-decide-busy');
+        alert(xhr.responseText || 'Error');
+      }
+    });
+  }
+
+  $(function(){
+    // --- Restrict the view to "internal note only" -----------------------
+    $('#post-reply-tab').closest('li').hide();
+    $('a.post-response[href="#post-reply"]').hide();
+    $('span.action-button[data-dropdown="#action-dropdown-statuses"]').hide();
+    $('a.action-button[href*="a=edit"]').hide();
+    $('a.ticket-action[href*="/status/close/"], a.ticket-action[href*="/status/reopen/"]')
+      .closest('.action-button, li').hide();
+    $('#post-note-tab').trigger('click');
+    $('a.post-response#post-note').trigger('click');
+    $('#note select[name=note_status_id]').prop('disabled', true).closest('tr').hide();
+
+    if (!IS_APPROVER) return;
+
+    // --- Banner buttons -------------------------------------------------
+    $('#p-approval-banner').on('click', 'button[data-decision]', function(){
+      var d = $(this).data('decision'), body = noteBody();
+      if (body) return submitDecision(d, body);
+      // Nothing typed yet -> open the dialog with its own reason box.
+      $.dialog(DECIDE_URL, [201], function(xhr, resp){
+        try { var j = JSON.parse(resp); if (j && j.redirect){ window.location.href = j.redirect; return false; } } catch(e){}
+      });
+    });
+
+    // --- Native buttons alongside "Post Note" --------------------------
+    var $noteBtns = $('#note input[type=submit].save').closest('p');
+    if ($noteBtns.length && !$noteBtns.find('.p-note-decide').length){
+      $('<span class="p-note-decide">'
+        + '<button type="button" class="green button action-button" data-decision="approve">'
+        +   '<i class="icon-ok-sign"></i> ' + <?php echo json_encode(__('Approve with note')); ?> + '</button>'
+        + '<button type="button" class="red button action-button" data-decision="reject">'
+        +   '<i class="icon-ban-circle"></i> ' + <?php echo json_encode(__('Decline with note')); ?> + '</button>'
+        + '</span>')
+        .prependTo($noteBtns)
+        .on('click', 'button[data-decision]', function(){
+          submitDecision($(this).data('decision'), noteBody());
+        });
+    }
+  });
+  })(window.jQuery);
+})();
+</script>


### PR DESCRIPTION
Add missing yead highly asked for feature as plugin

Holds tickets opened under a flagged Help Topic in a restricted holding department so they stay invisible to every agent except the topic's designated approvers, until one of them approves or rejects the ticket.

- Per-topic approver agents/teams configured in the plugin instance
- Approve moves the ticket to its normal department; reject adds a note and optionally closes it
- In-page workflow while pending: prominent Approve/Decline bar, forces the Internal Note tab, adds "Approve/Decline with note" buttons
- Timeline events (held / granted / rejected) via ThreadEvent subclasses
- Editable Email Templates (approval.needed / granted / rejected) registered under the Emails > Templates admin
- decision endpoint on the ajax.scp dispatcher re-checks approver rights